### PR TITLE
feat: add video metadata indexing with visual browser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,12 @@ tiktok-favvideo-downloader.exe my_data.json
 
 # Combine flags and custom file
 tiktok-favvideo-downloader.exe --flat-structure my_data.json
+
+# Skip thumbnail downloads (faster, less storage)
+tiktok-favvideo-downloader.exe --no-thumbnails
+
+# Regenerate indexes without re-downloading videos
+tiktok-favvideo-downloader.exe --index-only
 ```
 
 ### Collection Directory Structure
@@ -29,13 +35,49 @@ tiktok-favvideo-downloader.exe --flat-structure my_data.json
 project-folder/
 ├── tiktok-favvideo-downloader.exe
 ├── user_data_tiktok.json
-├── favorites/
-│   ├── fav_videos.txt
-│   └── [downloaded video files]
-└── liked/
-    ├── fav_videos.txt
-    └── [downloaded video files]
+│
+├── favorites/                                        # Favorited videos collection
+│   ├── fav_videos.txt                               # URL list (yt-dlp compatible)
+│   ├── index.json                                   # Machine-readable metadata index
+│   ├── index.html                                   # Visual browser (open in Chrome)
+│   ├── 20260129_7600559584901647646_Funny_Cat.mp4   # Video file
+│   ├── 20260129_7600559584901647646_Funny_Cat.info.json  # yt-dlp metadata
+│   ├── 20260129_7600559584901647646_Funny_Cat.jpg   # Thumbnail
+│   └── ...
+│
+└── liked/                                           # Liked videos collection (if opted in)
+    ├── liked_videos.txt                             # Note: different filename for liked
+    ├── index.json
+    ├── index.html
+    └── ...
 ```
+
+### Video Metadata & Indexing Feature
+
+After downloading videos, the application generates:
+
+1. **`index.html`** - Visual browser with:
+   - Thumbnail grid view
+   - Search by title, creator, or description
+   - Filter by download status (All/Downloaded/Failed)
+   - Click-to-play video modal
+   - Dark theme, works offline
+
+2. **`index.json`** - Machine-readable index with:
+   - Video metadata (title, creator, duration, views, etc.)
+   - Favorited dates from TikTok export
+   - Download status and local filenames
+   - Original TikTok URLs
+
+### Filename Format
+Videos are downloaded with the format: `%(upload_date)s_%(id)s_%(title).50B.%(ext)s`
+
+Example: `20260129_7600559584901647646_Funny_Cat_Video_Title.mp4`
+
+This includes:
+- Upload date for chronological sorting
+- Video ID for uniqueness
+- Truncated title (50 bytes) for identification
 
 ## Development Commands
 
@@ -96,36 +138,50 @@ go mod tidy
 This is a single-package Go application (`package main`) that downloads TikTok favorite/liked videos using yt-dlp. The main components are:
 
 - **Main executable**: `generate_tiktok_links.go` - Core application logic
-- **Tests**: `generate_tiktok_links_test.go` - Comprehensive test suite with 56.6% coverage
-- **No external dependencies**: Pure Go standard library implementation
+- **Tests**: `generate_tiktok_links_test.go` - Comprehensive test suite with 64.7% coverage
+- **Templates**: `templates/index.html` - Embedded HTML template for visual browser (via `//go:embed`)
+- **No external dependencies**: Pure Go standard library implementation (uses `embed` package)
 
 ### Key Components
 
 1. **JSON Data Parsing**: Parses TikTok's `user_data_tiktok.json` export file
    - `Data` struct defines the expected JSON structure
    - `parseFavoriteVideosFromFile()` extracts video entries with collection metadata
-   - `VideoEntry` struct contains Link, Date, and Collection information
+   - `VideoEntry` struct contains Link, Date, Collection, and extended metadata fields
 
 2. **Collection Organization**: Organizes videos by collection type (enabled by default)
    - `sanitizeCollectionName()` ensures collection names are valid directory names
    - `createCollectionDirectories()` creates subdirectories for each collection
    - `writeFavoriteVideosToFile()` writes videos to collection-specific files
+   - `getOutputFilename()` returns collection-specific filenames (fav_videos.txt vs liked_videos.txt)
    - Supports `--flat-structure` flag to disable organization
 
 3. **yt-dlp Integration**: Downloads and manages the yt-dlp executable
    - `getOrDownloadYtdlp()` automatically downloads latest yt-dlp.exe from GitHub if not present
-   - `runYtdlp()` executes yt-dlp with appropriate arguments for each collection
+   - `runYtdlp()` executes yt-dlp with `--write-info-json` and optional `--write-thumbnail` flags
+   - Supports `--no-thumbnails` flag to skip thumbnail downloads
+   - New filename format includes video ID and truncated title
 
-4. **CLI Flag Parsing**: Command-line argument handling
-   - `parseFlags()` handles `--flat-structure`, `--help` flags
+4. **Video Metadata & Indexing**: Generates browsable indexes after download
+   - `YtdlpInfo` struct for parsing yt-dlp's .info.json files
+   - `CollectionIndex` struct for the complete collection metadata
+   - `extractVideoID()` parses video IDs from TikTok URLs
+   - `parseInfoJSON()` reads yt-dlp metadata files
+   - `generateCollectionIndex()` creates index.json and index.html after download
+   - `getEntriesForCollection()` filters entries by collection name
+   - HTML template with search, filter, and embedded video player
+
+5. **CLI Flag Parsing**: Command-line argument handling
+   - `parseFlags()` handles `--flat-structure`, `--no-thumbnails`, `--index-only`, `--help` flags
    - `Config` struct stores application configuration
    - Supports positional arguments for custom JSON file paths
+   - `--index-only` mode regenerates indexes from existing .info.json files without downloading
 
-5. **Cross-platform Command Execution**: Handles PowerShell vs Command Prompt differences
+6. **Cross-platform Command Execution**: Handles PowerShell vs Command Prompt differences
    - `isRunningInPowershell()` detects PowerShell environment
    - Adjusts command prefixes accordingly (`.\` for PowerShell)
 
-6. **Version Management**: Uses build-time ldflags to inject version information
+7. **Version Management**: Uses build-time ldflags to inject version information
    - `version` variable is overridden during builds via `-ldflags="-X 'main.version=...'"`
 
 ### Testing Architecture

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -2,26 +2,82 @@ package main
 
 import (
 	"bufio"
+	_ "embed"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"time"
 )
 
 var (
 	version = "dev" // This will be overridden at build time via ldflags
+
+	// Pre-compiled regex patterns for extracting video IDs from TikTok URLs
+	videoIDPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`/video/(\d+)`),
+		regexp.MustCompile(`/v/(\d+)`),
+	}
 )
 
-// VideoEntry represents a video with its collection information
+// VideoEntry represents a video with its collection information and metadata
 type VideoEntry struct {
-	Link       string
-	Date       string
-	Collection string
+	// From TikTok JSON export
+	Link       string `json:"link"`
+	Date       string `json:"favorited_date"` // When user favorited/liked
+	Collection string `json:"collection"`     // "favorites" or "liked"
+
+	// Derived from URL
+	VideoID string `json:"video_id"`
+
+	// From yt-dlp metadata (populated after download)
+	Title         string `json:"title,omitempty"`
+	Creator       string `json:"creator,omitempty"`
+	CreatorID     string `json:"creator_id,omitempty"`
+	UploadDate    string `json:"upload_date,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Duration      int    `json:"duration,omitempty"`
+	ViewCount     int64  `json:"view_count,omitempty"`
+	LikeCount     int64  `json:"like_count,omitempty"`
+	ThumbnailURL  string `json:"thumbnail_url,omitempty"`
+	ThumbnailFile string `json:"thumbnail_file,omitempty"`
+
+	// Download status
+	Downloaded    bool   `json:"downloaded"`
+	LocalFilename string `json:"local_filename,omitempty"`
+	DownloadError string `json:"download_error,omitempty"`
+}
+
+// YtdlpInfo represents relevant fields from yt-dlp's .info.json files
+type YtdlpInfo struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Uploader    string `json:"uploader"`
+	UploaderID  string `json:"uploader_id"`
+	UploadDate  string `json:"upload_date"`
+	Description string `json:"description"`
+	Duration    int    `json:"duration"`
+	ViewCount   int64  `json:"view_count"`
+	LikeCount   int64  `json:"like_count"`
+	Thumbnail   string `json:"thumbnail"`
+	Filename    string `json:"filename"`
+}
+
+// CollectionIndex represents the complete index for a collection
+type CollectionIndex struct {
+	Name        string       `json:"name"`
+	GeneratedAt string       `json:"generated_at"`
+	TotalVideos int          `json:"total_videos"`
+	Downloaded  int          `json:"downloaded"`
+	Failed      int          `json:"failed"`
+	Videos      []VideoEntry `json:"videos"`
 }
 
 // Data represents the structure of user_data_tiktok.json
@@ -30,6 +86,7 @@ type Data struct {
 		FavoriteVideos struct {
 			FavoriteVideoList []struct {
 				Link string `json:"Link"`
+				Date string `json:"Date"` // Favorited date from TikTok export
 			} `json:"FavoriteVideoList"`
 		} `json:"Favorite Videos"`
 		LikedVideos struct {
@@ -44,9 +101,11 @@ type Data struct {
 // Config holds the application configuration
 type Config struct {
 	OrganizeByCollection bool
-	IncludeLiked        bool
-	JSONFile           string
-	OutputName         string
+	IncludeLiked         bool
+	SkipThumbnails       bool
+	IndexOnly            bool
+	JSONFile             string
+	OutputName           string
 }
 
 // getOrDownloadYtdlp checks if yt-dlp.exe is present in the current directory.
@@ -136,7 +195,7 @@ func parseFavoriteVideosFromFile(jsonFile string, includeLiked bool) ([]VideoEnt
 	for _, item := range data.Activity.FavoriteVideos.FavoriteVideoList {
 		videoEntries = append(videoEntries, VideoEntry{
 			Link:       item.Link,
-			Date:       "", // Favorite videos don't have dates in the current structure
+			Date:       item.Date,
 			Collection: "favorites",
 		})
 	}
@@ -168,6 +227,41 @@ func sanitizeCollectionName(name string) string {
 		name = "unknown"
 	}
 	return name
+}
+
+// extractVideoID extracts the video ID from a TikTok URL.
+// Supports various TikTok URL formats:
+//   - https://www.tiktokv.com/share/video/7600559584901647646/
+//   - https://www.tiktok.com/@user/video/7600559584901647646
+//   - https://m.tiktok.com/v/7600559584901647646.html
+func extractVideoID(url string) string {
+	for _, re := range videoIDPatterns {
+		if matches := re.FindStringSubmatch(url); len(matches) > 1 {
+			return matches[1]
+		}
+	}
+	return ""
+}
+
+// parseInfoJSON reads a yt-dlp .info.json file and extracts metadata
+func parseInfoJSON(infoPath string) (*YtdlpInfo, error) {
+	data, err := os.ReadFile(infoPath)
+	if err != nil {
+		return nil, err
+	}
+	var info YtdlpInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// getOutputFilename returns the appropriate URL list filename for a collection
+func getOutputFilename(collection string) string {
+	if collection == "liked" {
+		return "liked_videos.txt"
+	}
+	return "fav_videos.txt"
 }
 
 // createCollectionDirectories creates directories for each collection
@@ -204,9 +298,11 @@ func writeFavoriteVideosToFile(videoEntries []VideoEntry, outputName string, org
 			collectionGroups[collection] = append(collectionGroups[collection], entry)
 		}
 
-		// Write separate files for each collection
+		// Write separate files for each collection with collection-specific filenames
 		for collection, entries := range collectionGroups {
-			collectionOutputName := filepath.Join(collection, outputName)
+			// Use collection-specific filename (fav_videos.txt for favorites, liked_videos.txt for liked)
+			collectionFilename := getOutputFilename(collection)
+			collectionOutputName := filepath.Join(collection, collectionFilename)
 			if err := writeVideoEntriesToFile(entries, collectionOutputName); err != nil {
 				return err
 			}
@@ -259,31 +355,197 @@ func (r *RealCommandRunner) Run(name string, args ...string) error {
 }
 
 // runYtdlp runs the yt-dlp command for the user
-func runYtdlp(psPrefix, outputName string, organizeByCollection bool) {
-	runYtdlpWithRunner(&RealCommandRunner{}, psPrefix, outputName, organizeByCollection)
+func runYtdlp(psPrefix, outputName string, organizeByCollection, skipThumbnails bool) {
+	runYtdlpWithRunner(&RealCommandRunner{}, psPrefix, outputName, organizeByCollection, skipThumbnails)
 }
 
 // runYtdlpWithRunner allows dependency injection for testing
-func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, organizeByCollection bool) {
+func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, organizeByCollection, skipThumbnails bool) {
 	fmt.Println("[*] Running yt-dlp now...")
 	cmdStr := fmt.Sprintf("%syt-dlp.exe", psPrefix)
 
 	// Configure output format based on organization preference
+	// New format includes video ID and truncated title for better identification
 	var outputFormat string
 	if organizeByCollection {
 		// Include directory from outputName so videos download to collection folder
 		dir := filepath.Dir(outputName)
-		outputFormat = filepath.Join(dir, "%(upload_date)s_%(uploader_id)s.%(ext)s")
+		outputFormat = filepath.Join(dir, "%(upload_date)s_%(id)s_%(title).50B.%(ext)s")
 	} else {
-		// Flat structure with original format
-		outputFormat = "%(upload_date)s_%(uploader_id)s.%(ext)s"
+		// Flat structure with new format
+		outputFormat = "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"
 	}
 
-	if err := runner.Run(cmdStr, "-a", outputName, "--output", outputFormat); err != nil {
+	// Build yt-dlp arguments with metadata options
+	args := []string{
+		"-a", outputName,
+		"--output", outputFormat,
+		"--write-info-json", // Save metadata JSON for each video
+	}
+
+	// Add thumbnail download unless skipped
+	if !skipThumbnails {
+		args = append(args, "--write-thumbnail")
+	}
+
+	if err := runner.Run(cmdStr, args...); err != nil {
 		fmt.Printf("[!!!] Error running yt-dlp: %v\n", err)
 	} else {
 		fmt.Println("[*] yt-dlp completed successfully.")
 	}
+}
+
+// HTML template for the visual index browser
+//
+//go:embed templates/index.html
+var htmlTemplate string
+
+// getTemplateFuncs returns template helper functions
+func getTemplateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"formatDuration": func(seconds int) string {
+			m := seconds / 60
+			s := seconds % 60
+			return fmt.Sprintf("%d:%02d", m, s)
+		},
+		"formatNumber": func(n int64) string {
+			if n >= 1000000 {
+				return fmt.Sprintf("%.1fM", float64(n)/1000000)
+			}
+			if n >= 1000 {
+				return fmt.Sprintf("%.1fK", float64(n)/1000)
+			}
+			return fmt.Sprintf("%d", n)
+		},
+	}
+}
+
+// writeJSONIndex writes the collection index as JSON
+func writeJSONIndex(dir string, index *CollectionIndex) error {
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "index.json"), data, 0644)
+}
+
+// writeHTMLIndex generates the HTML visual browser
+func writeHTMLIndex(dir string, index *CollectionIndex) error {
+	tmpl, err := template.New("index").Funcs(getTemplateFuncs()).Parse(htmlTemplate)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(filepath.Join(dir, "index.html"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return tmpl.Execute(f, index)
+}
+
+// generateCollectionIndex creates JSON and HTML indexes for a collection after download.
+// It enriches entries with metadata from yt-dlp's .info.json files and generates
+// both index.json (machine-readable) and index.html (visual browser) files.
+func generateCollectionIndex(collectionDir string, entries []VideoEntry) error {
+	// 1. Scan for .info.json files in the directory
+	infoFiles, err := filepath.Glob(filepath.Join(collectionDir, "*.info.json"))
+	if err != nil {
+		return fmt.Errorf("error scanning for info files: %v", err)
+	}
+
+	// 2. Build video ID to info map
+	infoMap := make(map[string]*YtdlpInfo)
+	for _, f := range infoFiles {
+		info, err := parseInfoJSON(f)
+		if err != nil {
+			fmt.Printf("[!] Warning: Failed to parse %s: %v\n", f, err)
+			continue
+		}
+		infoMap[info.ID] = info
+	}
+
+	// 3. Create a copy of entries to avoid mutating the input slice
+	enrichedEntries := make([]VideoEntry, len(entries))
+	copy(enrichedEntries, entries)
+
+	// 4. Enrich entries with metadata
+	for i := range enrichedEntries {
+		videoID := extractVideoID(enrichedEntries[i].Link)
+		enrichedEntries[i].VideoID = videoID
+
+		if info, ok := infoMap[videoID]; ok {
+			enrichedEntries[i].Title = info.Title
+			enrichedEntries[i].Creator = info.Uploader
+			enrichedEntries[i].CreatorID = info.UploaderID
+			enrichedEntries[i].UploadDate = info.UploadDate
+			enrichedEntries[i].Description = info.Description
+			enrichedEntries[i].Duration = info.Duration
+			enrichedEntries[i].ViewCount = info.ViewCount
+			enrichedEntries[i].LikeCount = info.LikeCount
+			enrichedEntries[i].ThumbnailURL = info.Thumbnail
+			enrichedEntries[i].Downloaded = true
+
+			// Determine the local filename from the info
+			if info.Filename != "" {
+				enrichedEntries[i].LocalFilename = filepath.Base(info.Filename)
+			}
+
+			// Check for thumbnail file (try common extensions)
+			baseWithoutExt := strings.TrimSuffix(info.Filename, filepath.Ext(info.Filename))
+			for _, ext := range []string{".jpg", ".webp", ".png"} {
+				thumbPath := baseWithoutExt + ext
+				if _, err := os.Stat(filepath.Join(collectionDir, filepath.Base(thumbPath))); err == nil {
+					enrichedEntries[i].ThumbnailFile = filepath.Base(thumbPath)
+					break
+				}
+			}
+		} else {
+			enrichedEntries[i].Downloaded = false
+			enrichedEntries[i].DownloadError = "Video not downloaded or metadata unavailable"
+		}
+	}
+
+	// 5. Create index struct
+	index := CollectionIndex{
+		Name:        filepath.Base(collectionDir),
+		GeneratedAt: time.Now().Format("2006-01-02 15:04:05"),
+		TotalVideos: len(enrichedEntries),
+		Videos:      enrichedEntries,
+	}
+
+	// Count downloaded/failed
+	for _, e := range enrichedEntries {
+		if e.Downloaded {
+			index.Downloaded++
+		} else {
+			index.Failed++
+		}
+	}
+
+	// 5. Write JSON index
+	if err := writeJSONIndex(collectionDir, &index); err != nil {
+		return fmt.Errorf("error writing JSON index: %v", err)
+	}
+
+	// 6. Generate HTML index
+	if err := writeHTMLIndex(collectionDir, &index); err != nil {
+		return fmt.Errorf("error writing HTML index: %v", err)
+	}
+
+	return nil
+}
+
+// getEntriesForCollection filters video entries for a specific collection
+func getEntriesForCollection(entries []VideoEntry, collection string) []VideoEntry {
+	var result []VideoEntry
+	for _, e := range entries {
+		if sanitizeCollectionName(e.Collection) == collection {
+			result = append(result, e)
+		}
+	}
+	return result
 }
 
 func getExeName() string {
@@ -300,10 +562,12 @@ func getExeName() string {
 func parseFlags() *Config {
 	config := &Config{
 		OrganizeByCollection: true, // Default to organizing by collection
-		OutputName:          "fav_videos.txt",
+		OutputName:           "fav_videos.txt",
 	}
 
 	flatStructure := flag.Bool("flat-structure", false, "Disable collection organization (use flat directory structure)")
+	noThumbnails := flag.Bool("no-thumbnails", false, "Skip thumbnail download (faster, less storage)")
+	indexOnly := flag.Bool("index-only", false, "Regenerate indexes from existing .info.json files without downloading")
 	help := flag.Bool("help", false, "Show help message")
 	h := flag.Bool("h", false, "Show help message")
 
@@ -315,6 +579,8 @@ func parseFlags() *Config {
 	}
 
 	config.OrganizeByCollection = !*flatStructure
+	config.SkipThumbnails = *noThumbnails
+	config.IndexOnly = *indexOnly
 
 	// Handle positional argument for JSON file
 	args := flag.Args()
@@ -335,12 +601,16 @@ func printUsage() {
 	fmt.Printf("  %s [flags] [optional path to user_data_tiktok.json]\n", exeName)
 	fmt.Println("\nFlags:")
 	fmt.Println("  --flat-structure     Disable collection organization (use flat directory structure)")
-	fmt.Println("  --help, -h          Show this help message")
+	fmt.Println("  --no-thumbnails      Skip thumbnail download (faster, less storage)")
+	fmt.Println("  --index-only         Regenerate indexes from existing .info.json files")
+	fmt.Println("  --help, -h           Show this help message")
 	fmt.Println("\nExamples:")
 	fmt.Println("  1) Double-click (no arguments) if 'user_data_tiktok.json' is in the same folder.")
 	fmt.Printf("  2) Or drag & drop a JSON file onto '%s' to specify a different JSON file.\n", exeName)
 	fmt.Printf("  3) Or run from command line: %s path\\to\\my_tiktok_data.json\n", exeName)
 	fmt.Printf("  4) Use flat structure: %s --flat-structure\n", exeName)
+	fmt.Printf("  5) Skip thumbnails: %s --no-thumbnails\n", exeName)
+	fmt.Printf("  6) Regenerate index only: %s --index-only\n", exeName)
 	fmt.Println("\nCollection Organization (Default):")
 	fmt.Println("  Videos are organized into subdirectories by collection type:")
 	fmt.Println("    favorites/    - Your favorited videos")
@@ -365,6 +635,57 @@ func main() {
 		fmt.Printf("[!!!] Error: JSON file '%s' does not exist.\n", config.JSONFile)
 		printUsage()
 		os.Exit(1)
+	}
+
+	// Handle --index-only mode: regenerate indexes without downloading
+	if config.IndexOnly {
+		fmt.Println("[*] Index-only mode: regenerating indexes from existing .info.json files")
+
+		// Still need to ask about liked videos to know which collections to process
+		fmt.Print("[*] Would you like to include 'Liked' videos as well? (y/n, default is 'n'): ")
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		input := strings.TrimSpace(strings.ToLower(scanner.Text()))
+		if input == "y" || input == "yes" {
+			config.IncludeLiked = true
+		}
+
+		// Parse JSON to get video entries
+		videoEntries, err := parseFavoriteVideosFromFile(config.JSONFile, config.IncludeLiked)
+		if err != nil {
+			fmt.Printf("[!!!] Error parsing JSON: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("[*] Loaded %d video entries from '%s'\n", len(videoEntries), config.JSONFile)
+
+		if config.OrganizeByCollection {
+			// Regenerate indexes for each collection
+			collections := make(map[string]bool)
+			for _, entry := range videoEntries {
+				collections[sanitizeCollectionName(entry.Collection)] = true
+			}
+			for collection := range collections {
+				collectionEntries := getEntriesForCollection(videoEntries, collection)
+				if err := generateCollectionIndex(collection, collectionEntries); err != nil {
+					fmt.Printf("[!] Warning: Failed to generate index for %s: %v\n", collection, err)
+				} else {
+					fmt.Printf("[*] Generated index.html and index.json for %s\n", collection)
+				}
+			}
+		} else {
+			// Regenerate index for flat structure
+			dir, err := filepath.Abs(".")
+			if err != nil {
+				dir = "."
+			}
+			if err := generateCollectionIndex(dir, videoEntries); err != nil {
+				fmt.Printf("[!] Warning: Failed to generate index: %v\n", err)
+			} else {
+				fmt.Println("[*] Generated index.html and index.json")
+			}
+		}
+		return
 	}
 
 	// Attempt to get or download yt-dlp.exe
@@ -412,7 +733,7 @@ func main() {
 		fmt.Println("[*] Collection organization enabled. Videos will be downloaded to collection subdirectories.")
 		fmt.Println("[*] yt-dlp will process each collection's URL file separately.")
 	} else {
-		ytDlpCmd := fmt.Sprintf("%syt-dlp.exe -a \"%s\" --output \"%%(upload_date)s_%%(uploader_id)s.%%(ext)s\"", psPrefix, config.OutputName)
+		ytDlpCmd := fmt.Sprintf("%syt-dlp.exe -a \"%s\" --output \"%%(upload_date)s_%%(id)s_%%(title).50B.%%(ext)s\" --write-info-json --write-thumbnail", psPrefix, config.OutputName)
 		fmt.Println("[*] Done! You can now run yt-dlp like this:")
 		fmt.Printf("  %s\n", ytDlpCmd)
 	}
@@ -430,12 +751,33 @@ func main() {
 				collections[sanitizeCollectionName(entry.Collection)] = true
 			}
 			for collection := range collections {
-				collectionOutputName := filepath.Join(collection, config.OutputName)
+				// Use collection-specific filename
+				collectionFilename := getOutputFilename(collection)
+				collectionOutputName := filepath.Join(collection, collectionFilename)
 				fmt.Printf("[*] Processing collection: %s\n", collection)
-				runYtdlp(psPrefix, collectionOutputName, config.OrganizeByCollection)
+				runYtdlp(psPrefix, collectionOutputName, config.OrganizeByCollection, config.SkipThumbnails)
+
+				// Generate index after download completes
+				collectionEntries := getEntriesForCollection(videoEntries, collection)
+				if err := generateCollectionIndex(collection, collectionEntries); err != nil {
+					fmt.Printf("[!] Warning: Failed to generate index for %s: %v\n", collection, err)
+				} else {
+					fmt.Printf("[*] Generated index.html and index.json for %s\n", collection)
+				}
 			}
 		} else {
-			runYtdlp(psPrefix, config.OutputName, config.OrganizeByCollection)
+			runYtdlp(psPrefix, config.OutputName, config.OrganizeByCollection, config.SkipThumbnails)
+
+			// Generate index for flat structure in current directory
+			dir, err := filepath.Abs(".")
+			if err != nil {
+				dir = "."
+			}
+			if err := generateCollectionIndex(dir, videoEntries); err != nil {
+				fmt.Printf("[!] Warning: Failed to generate index: %v\n", err)
+			} else {
+				fmt.Println("[*] Generated index.html and index.json")
+			}
 		}
 	}
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.Name}} - TikTok Collection</title>
+    <style>
+        :root {
+            --bg-color: #1a1a2e;
+            --card-bg: #16213e;
+            --text-color: #eee;
+            --accent: #e94560;
+            --success: #4ecca3;
+            --error: #ff6b6b;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg-color);
+            color: var(--text-color);
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .header h1 { color: var(--accent); margin-bottom: 10px; }
+        .stats {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            flex-wrap: wrap;
+        }
+        .stat { padding: 10px 20px; background: var(--card-bg); border-radius: 8px; }
+        .stat-value { font-size: 1.5em; font-weight: bold; }
+        .stat-label { font-size: 0.9em; opacity: 0.8; }
+
+        .controls {
+            display: flex;
+            gap: 15px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+        .search-box {
+            flex: 1;
+            min-width: 200px;
+            padding: 12px;
+            border: none;
+            border-radius: 8px;
+            background: var(--card-bg);
+            color: var(--text-color);
+            font-size: 1em;
+        }
+        .search-box::placeholder { color: #888; }
+        .filter-btn {
+            padding: 12px 20px;
+            border: none;
+            border-radius: 8px;
+            background: var(--card-bg);
+            color: var(--text-color);
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .filter-btn:hover { background: var(--accent); }
+        .filter-btn.active { background: var(--accent); }
+
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 20px;
+        }
+        .video-card {
+            background: var(--card-bg);
+            border-radius: 12px;
+            overflow: hidden;
+            transition: transform 0.2s;
+        }
+        .video-card:hover { transform: translateY(-5px); }
+        .video-card.failed { opacity: 0.6; }
+
+        .thumbnail-container {
+            position: relative;
+            aspect-ratio: 9/16;
+            background: #000;
+        }
+        .thumbnail {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+        .no-thumbnail {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            color: #666;
+            font-size: 0.9em;
+        }
+        .duration {
+            position: absolute;
+            bottom: 8px;
+            right: 8px;
+            background: rgba(0,0,0,0.8);
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.85em;
+        }
+        .status-badge {
+            position: absolute;
+            top: 8px;
+            left: 8px;
+            padding: 4px 10px;
+            border-radius: 4px;
+            font-size: 0.75em;
+            font-weight: bold;
+        }
+        .status-downloaded { background: var(--success); color: #000; }
+        .status-failed { background: var(--error); color: #fff; }
+
+        .video-info { padding: 15px; }
+        .video-title {
+            font-weight: 600;
+            margin-bottom: 8px;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+        .video-meta {
+            font-size: 0.85em;
+            opacity: 0.7;
+        }
+        .video-meta span { margin-right: 15px; }
+
+        .video-link {
+            display: block;
+            text-decoration: none;
+            color: inherit;
+        }
+
+        .modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.95);
+            z-index: 1000;
+            justify-content: center;
+            align-items: center;
+        }
+        .modal.active { display: flex; }
+        .modal-content {
+            max-width: 90%;
+            max-height: 90%;
+        }
+        .modal video {
+            max-width: 100%;
+            max-height: 90vh;
+        }
+        .modal-close {
+            position: absolute;
+            top: 20px;
+            right: 30px;
+            font-size: 40px;
+            color: #fff;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>{{.Name}}</h1>
+        <p>Generated: {{.GeneratedAt}}</p>
+        <div class="stats">
+            <div class="stat">
+                <div class="stat-value">{{.TotalVideos}}</div>
+                <div class="stat-label">Total Videos</div>
+            </div>
+            <div class="stat">
+                <div class="stat-value" style="color: var(--success)">{{.Downloaded}}</div>
+                <div class="stat-label">Downloaded</div>
+            </div>
+            <div class="stat">
+                <div class="stat-value" style="color: var(--error)">{{.Failed}}</div>
+                <div class="stat-label">Failed</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="controls">
+        <input type="text" class="search-box" id="searchBox" placeholder="Search by title, creator, or description...">
+        <button class="filter-btn active" data-filter="all">All</button>
+        <button class="filter-btn" data-filter="downloaded">Downloaded</button>
+        <button class="filter-btn" data-filter="failed">Failed</button>
+    </div>
+
+    <div class="grid" id="videoGrid">
+        {{range .Videos}}
+        <div class="video-card {{if not .Downloaded}}failed{{end}}"
+             data-title="{{.Title}}"
+             data-creator="{{.Creator}}"
+             data-desc="{{.Description}}"
+             data-status="{{if .Downloaded}}downloaded{{else}}failed{{end}}"
+             data-file="{{.LocalFilename}}">
+            <a href="{{if .Downloaded}}{{.LocalFilename}}{{else}}{{.Link}}{{end}}" class="video-link" {{if .Downloaded}}onclick="openVideo(event, this)"{{else}}target="_blank"{{end}}>
+                <div class="thumbnail-container">
+                    {{if .ThumbnailFile}}
+                    <img class="thumbnail" src="{{.ThumbnailFile}}" alt="{{.Title}}" loading="lazy">
+                    {{else}}
+                    <div class="no-thumbnail">No Thumbnail</div>
+                    {{end}}
+                    {{if .Duration}}
+                    <span class="duration">{{formatDuration .Duration}}</span>
+                    {{end}}
+                    <span class="status-badge {{if .Downloaded}}status-downloaded{{else}}status-failed{{end}}">
+                        {{if .Downloaded}}Downloaded{{else}}Failed{{end}}
+                    </span>
+                </div>
+                <div class="video-info">
+                    <div class="video-title">{{if .Title}}{{.Title}}{{else}}Video {{.VideoID}}{{end}}</div>
+                    <div class="video-meta">
+                        {{if .Creator}}<span>@{{.Creator}}</span>{{end}}
+                        {{if .Date}}<span>Saved: {{.Date}}</span>{{end}}
+                        {{if .ViewCount}}<span>{{formatNumber .ViewCount}} views</span>{{end}}
+                    </div>
+                </div>
+            </a>
+        </div>
+        {{end}}
+    </div>
+
+    <div class="modal" id="videoModal">
+        <span class="modal-close" onclick="closeModal()">&times;</span>
+        <div class="modal-content">
+            <video id="modalVideo" controls></video>
+        </div>
+    </div>
+
+    <script>
+        const searchBox = document.getElementById('searchBox');
+        const cards = document.querySelectorAll('.video-card');
+
+        searchBox.addEventListener('input', filterCards);
+
+        function filterCards() {
+            const query = searchBox.value.toLowerCase();
+            const activeFilter = document.querySelector('.filter-btn.active').dataset.filter;
+
+            cards.forEach(card => {
+                const title = (card.dataset.title || '').toLowerCase();
+                const creator = (card.dataset.creator || '').toLowerCase();
+                const desc = (card.dataset.desc || '').toLowerCase();
+                const status = card.dataset.status;
+
+                const matchesSearch = !query ||
+                    title.includes(query) ||
+                    creator.includes(query) ||
+                    desc.includes(query);
+
+                const matchesFilter = activeFilter === 'all' || status === activeFilter;
+
+                card.style.display = (matchesSearch && matchesFilter) ? 'block' : 'none';
+            });
+        }
+
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                filterCards();
+            });
+        });
+
+        function openVideo(event, element) {
+            event.preventDefault();
+            const videoPath = element.getAttribute('href');
+            const modal = document.getElementById('videoModal');
+            const video = document.getElementById('modalVideo');
+            video.src = videoPath;
+            modal.classList.add('active');
+            video.play();
+        }
+
+        function closeModal() {
+            const modal = document.getElementById('videoModal');
+            const video = document.getElementById('modalVideo');
+            video.pause();
+            video.src = '';
+            modal.classList.remove('active');
+        }
+
+        document.addEventListener('keydown', e => {
+            if (e.key === 'Escape') closeModal();
+        });
+
+        document.getElementById('videoModal').addEventListener('click', e => {
+            if (e.target.id === 'videoModal') closeModal();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add comprehensive metadata capture and browsing capabilities:
- Generate index.html with thumbnail grid, search, and video player
- Generate index.json with machine-readable metadata
- Extract metadata from yt-dlp .info.json files
- Add --no-thumbnails flag to skip thumbnail downloads
- Add --index-only flag to regenerate indexes without downloading
- Embed HTML template using go:embed
- Support index generation for both collection and flat structures

Improved code quality:
- Fix slice mutation bug in generateCollectionIndex
- Compile regexes at package level for better performance
- Remove dead sanitizeForFilename function

BREAKING CHANGE: Filename format changed from %(upload_date)s_%(uploader_id)s.%(ext)s to %(upload_date)s_%(id)s_%(title).50B.%(ext)s. Users with existing downloads will have inconsistent naming.