### PR TITLE
fix: use actual yt-dlp version instead of file modtime for update check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,11 @@ This is a single-package Go application (`package main`) that downloads TikTok f
 
 3. **yt-dlp Integration**: Downloads and manages the yt-dlp executable
    - `getOrDownloadYtdlp()` automatically downloads latest yt-dlp.exe from GitHub if not present
+   - Version checking: compares local `yt-dlp --version` output against GitHub releases/latest
+   - `getYtdlpVersion()` runs `yt-dlp --version` to get local version (YYYY.MM.DD format)
+   - `getLatestYtdlpVersion()` fetches latest version from GitHub releases redirect URL
+   - `compareVersions()` compares version strings to detect outdated installations
+   - `updateYtdlp()` runs `yt-dlp --update` for self-update (with manual download fallback)
    - `runYtdlp()` executes yt-dlp with multiple flags:
      - `--write-info-json` - Save metadata for each video
      - `--write-thumbnail` - Download thumbnails (optional via `--no-thumbnails`)


### PR DESCRIPTION
The previous implementation checked if yt-dlp.exe file modification time was older than 30 days to determine if an update was needed. This was unreliable because downloading an old release would set the modtime to today, hiding that the version was actually outdated.

New implementation:
- getYtdlpVersion() runs `yt-dlp --version` to get actual version
- getLatestYtdlpVersion() fetches latest from GitHub /releases/latest redirect
- compareVersions() compares YYYY.MM.DD version strings
- updateYtdlp() uses `yt-dlp --update` as primary update method
- Falls back to manual download if self-update fails

Also shows user the current and latest versions before prompting for update.