### PR TITLE
v2.1.0 release work

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "WebFetch(domain:www.tiktok.com)",
       "Bash(go tool cover:*)",
       "Bash(ls:*)",
-      "Bash(./tiktok-favvideo-downloader.exe)"
+      "Bash(./tiktok-favvideo-downloader.exe)",
+      "Bash(git show:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,9 @@
       "Bash(go build:*)",
       "Bash(./tiktok-favvideo-downloader.exe --help)",
       "Bash(gh issue view:*)",
-      "Bash(golangci-lint run:*)"
+      "Bash(golangci-lint run:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,9 @@
       "Bash(yt-dlp:*)",
       "Bash(echo:*)",
       "WebFetch(domain:www.tiktok.com)",
-      "Bash(go tool cover:*)"
+      "Bash(go tool cover:*)",
+      "Bash(ls:*)",
+      "Bash(./tiktok-favvideo-downloader.exe)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,12 @@
       "Bash(gh issue view:*)",
       "Bash(golangci-lint run:*)",
       "Bash(git checkout:*)",
-      "Bash(git pull:*)"
+      "Bash(git pull:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(yt-dlp:*)",
+      "Bash(echo:*)",
+      "WebFetch(domain:www.tiktok.com)",
+      "Bash(go tool cover:*)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,25 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Photo/Slideshow Support (New!)
+## Photo/Slideshow Support
 
-TikTok photo slideshows (carousels) are now supported alongside videos. The application automatically:
+TikTok photo slideshows (carousels) are supported alongside videos. The application automatically:
 
-1. **Detects photo posts** by checking URL redirects (photo URLs contain `/photo/` instead of `/video/`)
-2. **Downloads photos using gallery-dl** (auto-downloaded like yt-dlp if not present)
-3. **Downloads videos using yt-dlp** (existing behavior)
+1. **Sends all URLs to yt-dlp first** (videos succeed, photos fail gracefully)
+2. **Falls back to gallery-dl** for URLs that yt-dlp couldn't handle
+3. **Caches results** so subsequent runs route directly without retrying
 4. **Generates unified indexes** that display both videos and photos
 
-### How Photo Detection Works
-- On startup, the app checks each URL from your TikTok export
-- URLs that redirect to `/photo/` paths are marked as photo posts
-- Photo URLs are routed to gallery-dl instead of yt-dlp
-- Detection adds a small delay (~100ms per URL) to avoid rate limiting
+### How Content Type Detection Works (yt-dlp First, gallery-dl Fallback)
+Instead of pre-detecting content types via HTTP requests (which TikTok rate-limits aggressively), the application uses a try-then-fallback approach:
+
+1. **Load cache**: `content_types_cache.json` stores known URL → type mappings from previous runs
+2. **Infer from files**: For uncached URLs, check what files exist on disk (`.info.json` = video, `.jpg`/`.png` = photo)
+3. **yt-dlp pass**: Send known-video + unknown entries to yt-dlp. Diff the download archive before/after to identify failures.
+4. **gallery-dl fallback**: Send known-photo entries + yt-dlp failures to gallery-dl
+5. **Update cache**: Save newly discovered content types for future runs
+
+This eliminates the slow pre-detection phase (which could take 2+ days for large collections due to TikTok rate limiting) and replaces it with a ~1 hour download cycle.
 
 ### What Gets Downloaded
 - **Videos**: MP4 files + thumbnails + metadata (via yt-dlp)
@@ -25,14 +30,14 @@ TikTok photo slideshows (carousels) are now supported alongside videos. The appl
 - Automatically downloaded from GitHub if not present
 - Version checked against latest release (same as yt-dlp)
 - Update prompts shown when newer version available
+- Photo archive (`photo_archive.txt`) tracks downloaded photos for skip optimization
 
-### Separate URL Files
-When photo posts are detected:
-- `fav_videos.txt` / `liked_videos.txt` - Video URLs for yt-dlp
-- `fav_photos.txt` / `liked_photos.txt` - Photo URLs for gallery-dl
+### URL Files
+- `fav_videos.txt` / `liked_videos.txt` - All URLs (videos + unknowns) for yt-dlp
+- `fav_photos.txt` / `liked_photos.txt` - Known photo URLs for gallery-dl
 
 ### Progress Reporting with Photos
-Session summaries now show separate stats:
+Session summaries show separate stats:
 ```
 Videos Attempted: 92
   ✓ Successfully Downloaded: 87
@@ -45,9 +50,9 @@ Photos Attempted: 15
 ```
 
 ### Limitations
-- Photo detection requires network requests (adds startup time)
 - gallery-dl is a separate ~10MB download
 - Photo metadata format differs slightly from video metadata
+- First run sends all unknown URLs through yt-dlp before gallery-dl (slightly slower if most URLs are photos)
 
 ---
 
@@ -209,11 +214,13 @@ project-folder/
 ├── yt-dlp.exe                                       # Auto-downloaded for video downloads
 ├── gallery-dl.exe                                   # Auto-downloaded for photo downloads
 ├── user_data_tiktok.json
+├── content_types_cache.json                         # Cached URL → content type mappings
 │
 ├── favorites/                                        # Favorited content collection
 │   ├── fav_videos.txt                               # Video URL list (yt-dlp)
 │   ├── fav_photos.txt                               # Photo URL list (gallery-dl)
 │   ├── download_archive.txt                         # Resume tracking (skips downloaded videos)
+│   ├── photo_archive.txt                            # Resume tracking (skips downloaded photos)
 │   ├── index.json                                   # Machine-readable metadata index
 │   ├── index.html                                   # Visual browser (open in Chrome)
 │   │
@@ -233,6 +240,7 @@ project-folder/
     ├── liked_videos.txt                             # Note: different filename for liked
     ├── liked_photos.txt                             # Photo URLs for liked collection
     ├── download_archive.txt                         # Resume tracking for liked videos
+    ├── photo_archive.txt                            # Resume tracking for liked photos
     ├── index.json
     ├── index.html
     └── ...
@@ -427,10 +435,12 @@ This is a single-package Go application (`package main`) that downloads TikTok f
    - `parseFavoriteVideosFromFile()` extracts video entries with collection metadata
    - `VideoEntry` struct contains Link, Date, Collection, ContentType, and extended metadata fields
 
-2. **Content Type Detection**: Detects whether URLs are videos or photos
-   - `isPhotoPost()` follows URL redirects to detect `/photo/` vs `/video/` URLs
-   - `detectContentTypes()` batch-processes all URLs with rate limiting (100ms delay)
+2. **Content Type Resolution**: Determines whether URLs are videos or photos without network requests
+   - `applyContentTypesFromCache()` loads types from cache file and infers from files on disk
+   - `inferContentTypeFromFiles()` checks for `.info.json` (video) or image files (photo) on disk
+   - `identifyFailedEntries()` diffs download archive before/after yt-dlp to find failures
    - `separateEntriesByContentType()` splits entries into video and photo lists
+   - Content type cache (`content_types_cache.json`) persists results across runs
 
 3. **Collection Organization**: Organizes content by collection type (enabled by default)
    - `sanitizeCollectionName()` ensures collection names are valid directory names
@@ -465,6 +475,9 @@ This is a single-package Go application (`package main`) that downloads TikTok f
      - `--write-metadata` - Save metadata JSON for each photo
    - Supports same cookie flags as yt-dlp
    - `parseGalleryDlOutput()` parses gallery-dl output for success/failure counting
+   - Photo archive (`photo_archive.txt`) tracks downloaded photos for skip optimization
+   - `appendToPhotoArchive()` writes successfully downloaded photo IDs after gallery-dl run
+   - `getPhotoArchivePath()` returns archive path based on collection organization mode
 
 4. **Real-Time Progress Bar**: Live download progress visualization
    - `ProgressState` struct tracks current download progress (current index, total, success/failure counts)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,61 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Photo/Slideshow Support (New!)
+
+TikTok photo slideshows (carousels) are now supported alongside videos. The application automatically:
+
+1. **Detects photo posts** by checking URL redirects (photo URLs contain `/photo/` instead of `/video/`)
+2. **Downloads photos using gallery-dl** (auto-downloaded like yt-dlp if not present)
+3. **Downloads videos using yt-dlp** (existing behavior)
+4. **Generates unified indexes** that display both videos and photos
+
+### How Photo Detection Works
+- On startup, the app checks each URL from your TikTok export
+- URLs that redirect to `/photo/` paths are marked as photo posts
+- Photo URLs are routed to gallery-dl instead of yt-dlp
+- Detection adds a small delay (~100ms per URL) to avoid rate limiting
+
+### What Gets Downloaded
+- **Videos**: MP4 files + thumbnails + metadata (via yt-dlp)
+- **Photos**: All images in the slideshow (JPG/PNG/WebP) + audio track (M4A) + metadata (via gallery-dl)
+
+### gallery-dl Management
+- Automatically downloaded from GitHub if not present
+- Version checked against latest release (same as yt-dlp)
+- Update prompts shown when newer version available
+
+### Separate URL Files
+When photo posts are detected:
+- `fav_videos.txt` / `liked_videos.txt` - Video URLs for yt-dlp
+- `fav_photos.txt` / `liked_photos.txt` - Photo URLs for gallery-dl
+
+### Progress Reporting with Photos
+Session summaries now show separate stats:
+```
+Videos Attempted: 92
+  ✓ Successfully Downloaded: 87
+  - Skipped (Already Downloaded): 3
+  ✗ Failed: 2
+
+Photos Attempted: 15
+  ✓ Successfully Downloaded: 14
+  ✗ Failed: 1
+```
+
+### Limitations
+- Photo detection requires network requests (adds startup time)
+- gallery-dl is a separate ~10MB download
+- Photo metadata format differs slightly from video metadata
+
+---
+
 ## Collection Organization Feature
 
 ### Default Behavior
-By default, the application organizes downloaded videos into collection-based subdirectories:
-- `favorites/` - Contains favorited videos with their URL list file
-- `liked/` - Contains liked videos with their URL list file
+By default, the application organizes downloaded content into collection-based subdirectories:
+- `favorites/` - Contains favorited videos/photos with their URL list files
+- `liked/` - Contains liked videos/photos with their URL list files
 
 ### Usage Examples
 ```bash
@@ -157,39 +206,54 @@ This is useful for:
 ```
 project-folder/
 ├── tiktok-favvideo-downloader.exe
+├── yt-dlp.exe                                       # Auto-downloaded for video downloads
+├── gallery-dl.exe                                   # Auto-downloaded for photo downloads
 ├── user_data_tiktok.json
 │
-├── favorites/                                        # Favorited videos collection
-│   ├── fav_videos.txt                               # URL list (yt-dlp compatible)
+├── favorites/                                        # Favorited content collection
+│   ├── fav_videos.txt                               # Video URL list (yt-dlp)
+│   ├── fav_photos.txt                               # Photo URL list (gallery-dl)
 │   ├── download_archive.txt                         # Resume tracking (skips downloaded videos)
 │   ├── index.json                                   # Machine-readable metadata index
 │   ├── index.html                                   # Visual browser (open in Chrome)
+│   │
+│   │ # Video files (from yt-dlp):
 │   ├── 20260129_7600559584901647646_Funny_Cat.mp4   # Video file
 │   ├── 20260129_7600559584901647646_Funny_Cat.info.json  # yt-dlp metadata
 │   ├── 20260129_7600559584901647646_Funny_Cat.jpg   # Thumbnail
+│   │
+│   │ # Photo slideshow files (from gallery-dl):
+│   ├── 20260129_7597601281703693623_Slideshow_1.jpg # First image
+│   ├── 20260129_7597601281703693623_Slideshow_2.jpg # Second image
+│   ├── 20260129_7597601281703693623_Slideshow.m4a   # Audio track
+│   ├── 20260129_7597601281703693623_Slideshow.json  # gallery-dl metadata
 │   └── ...
 │
-└── liked/                                           # Liked videos collection (if opted in)
+└── liked/                                           # Liked content collection (if opted in)
     ├── liked_videos.txt                             # Note: different filename for liked
+    ├── liked_photos.txt                             # Photo URLs for liked collection
     ├── download_archive.txt                         # Resume tracking for liked videos
     ├── index.json
     ├── index.html
     └── ...
 ```
 
-### Video Metadata & Indexing Feature
+### Video & Photo Metadata & Indexing Feature
 
-After downloading videos, the application generates:
+After downloading content, the application generates:
 
 1. **`index.html`** - Visual browser with:
-   - Thumbnail grid view
+   - Thumbnail grid view (uses first image for photo slideshows)
    - Search by title, creator, or description
    - Filter by download status (All/Downloaded/Failed)
    - Click-to-play video modal
+   - Photo slideshow viewer for multi-image posts
    - Dark theme, works offline
 
 2. **`index.json`** - Machine-readable index with:
    - Video metadata (title, creator, duration, views, etc.)
+   - Photo metadata (image count, image files, audio file)
+   - Content type indicator ("video" or "photo")
    - Favorited dates from TikTok export
    - Download status and local filenames
    - Original TikTok URLs
@@ -349,10 +413,10 @@ go mod tidy
 ## Architecture
 
 ### Project Structure
-This is a single-package Go application (`package main`) that downloads TikTok favorite/liked videos using yt-dlp. The main components are:
+This is a single-package Go application (`package main`) that downloads TikTok favorite/liked videos and photos using yt-dlp and gallery-dl. The main components are:
 
 - **Main executable**: `generate_tiktok_links.go` - Core application logic
-- **Tests**: `generate_tiktok_links_test.go` - Comprehensive test suite with 64.7% coverage
+- **Tests**: `generate_tiktok_links_test.go` - Comprehensive test suite
 - **Templates**: `templates/index.html` - Embedded HTML template for visual browser (via `//go:embed`)
 - **No external dependencies**: Pure Go standard library implementation (uses `embed` package)
 
@@ -361,16 +425,21 @@ This is a single-package Go application (`package main`) that downloads TikTok f
 1. **JSON Data Parsing**: Parses TikTok's `user_data_tiktok.json` export file
    - `Data` struct defines the expected JSON structure
    - `parseFavoriteVideosFromFile()` extracts video entries with collection metadata
-   - `VideoEntry` struct contains Link, Date, Collection, and extended metadata fields
+   - `VideoEntry` struct contains Link, Date, Collection, ContentType, and extended metadata fields
 
-2. **Collection Organization**: Organizes videos by collection type (enabled by default)
+2. **Content Type Detection**: Detects whether URLs are videos or photos
+   - `isPhotoPost()` follows URL redirects to detect `/photo/` vs `/video/` URLs
+   - `detectContentTypes()` batch-processes all URLs with rate limiting (100ms delay)
+   - `separateEntriesByContentType()` splits entries into video and photo lists
+
+3. **Collection Organization**: Organizes content by collection type (enabled by default)
    - `sanitizeCollectionName()` ensures collection names are valid directory names
    - `createCollectionDirectories()` creates subdirectories for each collection
-   - `writeFavoriteVideosToFile()` writes videos to collection-specific files
-   - `getOutputFilename()` returns collection-specific filenames (fav_videos.txt vs liked_videos.txt)
+   - `writeFavoriteVideosToFile()` writes videos and photos to separate collection-specific files
+   - `getVideoOutputFilename()` / `getPhotoOutputFilename()` return appropriate filenames
    - Supports `--flat-structure` flag to disable organization
 
-3. **yt-dlp Integration**: Downloads and manages the yt-dlp executable
+4. **yt-dlp Integration**: Downloads and manages yt-dlp for video content
    - `getOrDownloadYtdlp()` automatically downloads latest yt-dlp.exe from GitHub if not present
    - `runYtdlp()` executes yt-dlp with multiple flags:
      - `--write-info-json` - Save metadata for each video
@@ -383,6 +452,19 @@ This is a single-package Go application (`package main`) that downloads TikTok f
    - Supports `--disable-resume` flag to force re-download all videos
    - Supports `--no-progress-bar` flag to disable real-time progress display
    - New filename format includes video ID and truncated title
+
+5. **gallery-dl Integration**: Downloads and manages gallery-dl for photo/slideshow content
+   - `getOrDownloadGalleryDl()` automatically downloads latest gallery-dl.exe from GitHub if not present
+   - `getGalleryDlVersion()` runs `gallery-dl --version` to get local version (X.Y.Z format)
+   - `getLatestGalleryDlVersion()` fetches latest version from GitHub releases redirect URL
+   - `compareGalleryDlVersions()` compares semantic version strings
+   - `runGalleryDl()` executes gallery-dl with appropriate flags:
+     - `--input-file` - Read URLs from file
+     - `--directory` - Output directory
+     - `--filename` - Filename format matching yt-dlp pattern
+     - `--write-metadata` - Save metadata JSON for each photo
+   - Supports same cookie flags as yt-dlp
+   - `parseGalleryDlOutput()` parses gallery-dl output for success/failure counting
 
 4. **Real-Time Progress Bar**: Live download progress visualization
    - `ProgressState` struct tracks current download progress (current index, total, success/failure counts)

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -28,6 +28,13 @@ var (
 		regexp.MustCompile(`/photo/(\d+)`),
 		regexp.MustCompile(`/v/(\d+)`),
 	}
+
+	// Pre-compiled regex patterns for parsing yt-dlp and gallery-dl output
+	ytdlpErrorPattern    = regexp.MustCompile(`ERROR:\s*\[TikTok\]\s*(\d+):\s*(.+)`)
+	progressLinePattern  = regexp.MustCompile(`\[download\] Downloading item (\d+) of (\d+)`)
+	gallerySuccessPattern = regexp.MustCompile(`^#\d+`)
+	galleryErrorPattern   = regexp.MustCompile(`(?i)error|failed|\[error\]`)
+	galleryVideoIDPattern = regexp.MustCompile(`(\d{19})`)
 )
 
 // VideoEntry represents a video or photo with its collection information and metadata
@@ -1412,10 +1419,8 @@ func parseYtdlpOutput(lines []string, entries []VideoEntry) []FailureDetail {
 	}
 
 	// Regex: ERROR: [TikTok] VIDEO_ID: error message
-	errorPattern := regexp.MustCompile(`ERROR:\s*\[TikTok\]\s*(\d+):\s*(.+)`)
-
 	for _, line := range lines {
-		matches := errorPattern.FindStringSubmatch(line)
+		matches := ytdlpErrorPattern.FindStringSubmatch(line)
 		if len(matches) >= 3 {
 			videoID := matches[1]
 			errorMsg := strings.TrimSpace(matches[2])
@@ -1460,8 +1465,7 @@ func categorizeError(errorMsg string) ErrorType {
 // Returns: (currentIndex, total, isProgressLine, error)
 func parseProgressLine(line string) (int, int, bool, error) {
 	// Match pattern: [download] Downloading item X of Y
-	re := regexp.MustCompile(`\[download\] Downloading item (\d+) of (\d+)`)
-	matches := re.FindStringSubmatch(line)
+	matches := progressLinePattern.FindStringSubmatch(line)
 
 	if len(matches) != 3 {
 		return 0, 0, false, nil // Not a progress line
@@ -2115,16 +2119,11 @@ func parseGalleryDlOutput(lines []string, entries []VideoEntry) (success int, fa
 	// Track which video IDs we've seen in success messages
 	seenIDs := make(map[string]bool)
 
-	// Regex patterns for gallery-dl output
-	successPattern := regexp.MustCompile(`^#\d+`)
-	errorPattern := regexp.MustCompile(`(?i)error|failed|\[error\]`)
-	videoIDPattern := regexp.MustCompile(`(\d{19})`) // TikTok video IDs are 19 digits
-
 	for _, line := range lines {
 		// Check for error lines
-		if errorPattern.MatchString(line) {
+		if galleryErrorPattern.MatchString(line) {
 			// Extract video ID from error line
-			if matches := videoIDPattern.FindStringSubmatch(line); len(matches) > 1 {
+			if matches := galleryVideoIDPattern.FindStringSubmatch(line); len(matches) > 1 {
 				videoID := matches[1]
 				if !seenIDs[videoID] {
 					failures = append(failures, FailureDetail{
@@ -2139,9 +2138,9 @@ func parseGalleryDlOutput(lines []string, entries []VideoEntry) (success int, fa
 		}
 
 		// Check for success lines (starts with #number)
-		if successPattern.MatchString(line) {
+		if gallerySuccessPattern.MatchString(line) {
 			// Try to extract video ID from the line
-			if matches := videoIDPattern.FindStringSubmatch(line); len(matches) > 1 {
+			if matches := galleryVideoIDPattern.FindStringSubmatch(line); len(matches) > 1 {
 				seenIDs[matches[1]] = true
 			}
 			success++

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -1865,11 +1865,11 @@ func writeTroubleshootingTips(w *bufio.Writer, session *DownloadSession) {
 }
 
 // runYtdlp runs the yt-dlp command for the user
-func runYtdlp(psPrefix, outputName string, organizeByCollection, skipThumbnails, disableResume, disableProgressBar bool, cookieFile, cookieFromBrowser string, entries []VideoEntry) (*CollectionResult, error) {
+func runYtdlp(psPrefix, outputName string, config *Config, entries []VideoEntry) (*CollectionResult, error) {
 	// Create progress renderer if enabled
 	var renderer *ProgressRenderer
 	var state *ProgressState
-	if !disableProgressBar && supportsANSI() {
+	if !config.DisableProgressBar && supportsANSI() {
 		collectionName := filepath.Base(filepath.Dir(outputName))
 		if collectionName == "." {
 			collectionName = "videos"
@@ -1889,19 +1889,19 @@ func runYtdlp(psPrefix, outputName string, organizeByCollection, skipThumbnails,
 		ProgressState:    state,
 	}
 
-	return runYtdlpWithRunner(runner, psPrefix, outputName, organizeByCollection, skipThumbnails, disableResume, cookieFile, cookieFromBrowser, entries)
+	return runYtdlpWithRunner(runner, psPrefix, outputName, config, entries)
 }
 
 // runYtdlpWithRunner allows dependency injection for testing
-func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, organizeByCollection, skipThumbnails, disableResume bool, cookieFile, cookieFromBrowser string, entries []VideoEntry) (*CollectionResult, error) {
+func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, config *Config, entries []VideoEntry) (*CollectionResult, error) {
 	collectionName := filepath.Base(filepath.Dir(outputName))
 	if collectionName == "." {
 		collectionName = "videos"
 	}
 
-	// Calculate archive file path (matches logic below at lines 1159-1165)
+	// Calculate archive file path
 	var archivePath string
-	if organizeByCollection {
+	if config.OrganizeByCollection {
 		dir := filepath.Dir(outputName)
 		archivePath = filepath.Join(dir, "download_archive.txt")
 	} else {
@@ -1912,7 +1912,7 @@ func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, organ
 	videosToDownload := entries
 	skippedCount := 0
 
-	if !disableResume {
+	if !config.DisableResume {
 		archive, err := parseArchiveFile(archivePath)
 		if err == nil && len(archive) > 0 {
 			var filtered []VideoEntry
@@ -1964,7 +1964,7 @@ func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, organ
 	// Configure output format based on organization preference
 	// New format includes video ID and truncated title for better identification
 	var outputFormat string
-	if organizeByCollection {
+	if config.OrganizeByCollection {
 		// Include directory from outputName so videos download to collection folder
 		dir := filepath.Dir(outputName)
 		outputFormat = filepath.Join(dir, "%(upload_date)s_%(id)s_%(title).50B.%(ext)s")
@@ -1980,7 +1980,7 @@ func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, organ
 	if skippedCount > 0 {
 		tempFile := outputName + ".partial.txt"
 		// Ensure directory exists (should already exist from main, but just in case)
-		if organizeByCollection {
+		if config.OrganizeByCollection {
 			_ = os.MkdirAll(filepath.Dir(tempFile), 0755)
 		}
 
@@ -2006,21 +2006,21 @@ func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, organ
 	}
 
 	// Add thumbnail download unless skipped
-	if !skipThumbnails {
+	if !config.SkipThumbnails {
 		args = append(args, "--write-thumbnail")
 		args = append(args, "--convert-thumbnails", "jpg") // Ensure consistent .jpg extension
 	}
 
 	// Add cookie arguments if configured
-	if cookieFile != "" {
-		args = append(args, "--cookies", cookieFile)
+	if config.CookieFile != "" {
+		args = append(args, "--cookies", config.CookieFile)
 	}
-	if cookieFromBrowser != "" {
-		args = append(args, "--cookies-from-browser", cookieFromBrowser)
+	if config.CookieFromBrowser != "" {
+		args = append(args, "--cookies-from-browser", config.CookieFromBrowser)
 	}
 
 	// Add resume functionality flags unless disabled
-	if !disableResume {
+	if !config.DisableResume {
 		// Add flags for resume functionality
 		args = append(args, "--download-archive", archivePath)
 		args = append(args, "--no-overwrites")
@@ -2130,7 +2130,7 @@ func parseGalleryDlOutput(lines []string, entries []VideoEntry) (success int, fa
 }
 
 // runGalleryDl runs gallery-dl to download photo/slideshow posts
-func runGalleryDl(psPrefix, outputDir string, organizeByCollection bool, entries []VideoEntry, cookieFile, cookieFromBrowser string) (*CollectionResult, error) {
+func runGalleryDl(psPrefix, outputDir string, config *Config, entries []VideoEntry) (*CollectionResult, error) {
 	if len(entries) == 0 {
 		return &CollectionResult{
 			Name:           filepath.Base(outputDir),
@@ -2170,11 +2170,11 @@ func runGalleryDl(psPrefix, outputDir string, organizeByCollection bool, entries
 	}
 
 	// Add cookie support
-	if cookieFile != "" {
-		args = append(args, "--cookies", cookieFile)
+	if config.CookieFile != "" {
+		args = append(args, "--cookies", config.CookieFile)
 	}
-	if cookieFromBrowser != "" {
-		args = append(args, "--cookies-from-browser", cookieFromBrowser)
+	if config.CookieFromBrowser != "" {
+		args = append(args, "--cookies-from-browser", config.CookieFromBrowser)
 	}
 
 	// Execute command
@@ -2977,7 +2977,7 @@ func main() {
 					collectionOutputName := filepath.Join(collection, collectionFilename)
 
 					fmt.Printf("[*] Processing collection: %s (%d videos)\n", collection, len(collectionVideos))
-					result, _ := runYtdlp(psPrefix, collectionOutputName, config.OrganizeByCollection, config.SkipThumbnails, config.DisableResume, config.DisableProgressBar, config.CookieFile, config.CookieFromBrowser, collectionVideos)
+					result, _ := runYtdlp(psPrefix, collectionOutputName, config, collectionVideos)
 
 					// Track session results
 					if result != nil {
@@ -2990,7 +2990,7 @@ func main() {
 				// Process photos with gallery-dl
 				if len(collectionPhotos) > 0 && galleryDlAvailable {
 					fmt.Printf("[*] Processing collection: %s (%d photos)\n", collection, len(collectionPhotos))
-					result, _ := runGalleryDl(psPrefix, collection, config.OrganizeByCollection, collectionPhotos, config.CookieFile, config.CookieFromBrowser)
+					result, _ := runGalleryDl(psPrefix, collection, config, collectionPhotos)
 
 					// Track session results
 					if result != nil {
@@ -3014,7 +3014,7 @@ func main() {
 
 			// Process videos with yt-dlp
 			if len(flatVideos) > 0 {
-				result, _ := runYtdlp(psPrefix, config.OutputName, config.OrganizeByCollection, config.SkipThumbnails, config.DisableResume, config.DisableProgressBar, config.CookieFile, config.CookieFromBrowser, flatVideos)
+				result, _ := runYtdlp(psPrefix, config.OutputName, config, flatVideos)
 
 				// Track session results
 				if result != nil {
@@ -3028,7 +3028,7 @@ func main() {
 			if len(flatPhotos) > 0 && galleryDlAvailable {
 				fmt.Printf("[*] Processing %d photos with gallery-dl...\n", len(flatPhotos))
 				dir, _ := filepath.Abs(".")
-				result, _ := runGalleryDl(psPrefix, dir, config.OrganizeByCollection, flatPhotos, config.CookieFile, config.CookieFromBrowser)
+				result, _ := runGalleryDl(psPrefix, dir, config, flatPhotos)
 
 				// Track session results
 				if result != nil {

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -25,11 +25,12 @@ var (
 	// Pre-compiled regex patterns for extracting video IDs from TikTok URLs
 	videoIDPatterns = []*regexp.Regexp{
 		regexp.MustCompile(`/video/(\d+)`),
+		regexp.MustCompile(`/photo/(\d+)`),
 		regexp.MustCompile(`/v/(\d+)`),
 	}
 )
 
-// VideoEntry represents a video with its collection information and metadata
+// VideoEntry represents a video or photo with its collection information and metadata
 type VideoEntry struct {
 	// From TikTok JSON export
 	Link       string `json:"link"`
@@ -37,23 +38,29 @@ type VideoEntry struct {
 	Collection string `json:"collection"`     // "favorites" or "liked"
 
 	// Derived from URL
-	VideoID string `json:"video_id"`
+	VideoID     string `json:"video_id"`
+	ContentType string `json:"content_type,omitempty"` // "video" or "photo" (detected at download time)
 
-	// From yt-dlp metadata (populated after download)
+	// From yt-dlp/gallery-dl metadata (populated after download)
 	Title         string `json:"title,omitempty"`
 	Creator       string `json:"creator,omitempty"`
 	CreatorID     string `json:"creator_id,omitempty"`
 	UploadDate    string `json:"upload_date,omitempty"`
 	Description   string `json:"description,omitempty"`
-	Duration      int    `json:"duration,omitempty"`
+	Duration      int    `json:"duration,omitempty"` // 0 for photos
 	ViewCount     int64  `json:"view_count,omitempty"`
 	LikeCount     int64  `json:"like_count,omitempty"`
 	ThumbnailURL  string `json:"thumbnail_url,omitempty"`
 	ThumbnailFile string `json:"thumbnail_file,omitempty"`
 
+	// Photo-specific fields
+	ImageCount int      `json:"image_count,omitempty"` // Number of images in slideshow
+	ImageFiles []string `json:"image_files,omitempty"` // List of local image filenames
+	AudioFile  string   `json:"audio_file,omitempty"`  // Audio track filename (for slideshows)
+
 	// Download status
 	Downloaded    bool   `json:"downloaded"`
-	LocalFilename string `json:"local_filename,omitempty"`
+	LocalFilename string `json:"local_filename,omitempty"` // For videos; first image for photos
 	DownloadError string `json:"download_error,omitempty"`
 }
 
@@ -98,11 +105,16 @@ type DownloadSession struct {
 	TotalSuccess   int
 	TotalFailed    int
 	TotalSkipped   int
+	// Photo-specific tracking
+	TotalPhotosAttempted int
+	TotalPhotosSuccess   int
+	TotalPhotosFailed    int
 }
 
 // CollectionResult tracks results for a single collection
 type CollectionResult struct {
 	Name           string
+	ContentType    string // "video", "photo", or "" (legacy/mixed)
 	Attempted      int
 	Success        int
 	Failed         int
@@ -116,6 +128,7 @@ type FailureDetail struct {
 	VideoURL     string
 	ErrorMessage string
 	ErrorType    ErrorType
+	ContentType  string // "video" or "photo"
 }
 
 // ErrorType categorizes common error types
@@ -356,6 +369,237 @@ func getOrDownloadYtdlp(client *http.Client, exeName string) error {
 	return downloadLatestYtdlp(client, exeName)
 }
 
+// getGalleryDlVersion runs gallery-dl --version and returns the version string
+func getGalleryDlVersion(exePath string) (string, error) {
+	cmd := exec.Command(exePath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run %s --version: %v", exePath, err)
+	}
+	// gallery-dl outputs "gallery-dl X.Y.Z" so extract version number
+	version := strings.TrimSpace(string(output))
+	// Parse "gallery-dl X.Y.Z" format
+	parts := strings.Fields(version)
+	if len(parts) >= 2 {
+		return parts[len(parts)-1], nil
+	}
+	if version == "" {
+		return "", fmt.Errorf("gallery-dl --version returned empty output")
+	}
+	return version, nil
+}
+
+// getLatestGalleryDlVersion fetches the latest gallery-dl version from GitHub releases
+func getLatestGalleryDlVersion(client *http.Client) (string, error) {
+	// Create a client that doesn't follow redirects so we can capture the Location header
+	checkRedirect := client.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse // Don't follow redirects
+	}
+	defer func() { client.CheckRedirect = checkRedirect }()
+
+	resp, err := client.Get("https://github.com/mikf/gallery-dl/releases/latest")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch GitHub releases: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// GitHub returns 302 redirect to /releases/tag/vX.Y.Z
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusMovedPermanently {
+		return "", fmt.Errorf("unexpected response status: %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", fmt.Errorf("no redirect location in response")
+	}
+
+	// Extract version from URL like https://github.com/mikf/gallery-dl/releases/tag/v1.28.0
+	parts := strings.Split(location, "/tag/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected redirect URL format: %s", location)
+	}
+
+	version := strings.TrimSpace(parts[1])
+	// Remove 'v' prefix if present (gallery-dl uses v1.28.0 format)
+	version = strings.TrimPrefix(version, "v")
+	if version == "" {
+		return "", fmt.Errorf("empty version in redirect URL")
+	}
+
+	return version, nil
+}
+
+// compareGalleryDlVersions compares two gallery-dl version strings in X.Y.Z format
+// Returns: -1 if local < remote (needs update), 0 if equal, 1 if local > remote
+func compareGalleryDlVersions(local, remote string) int {
+	// Parse semantic versions (X.Y.Z format)
+	localParts := strings.Split(local, ".")
+	remoteParts := strings.Split(remote, ".")
+
+	// Compare each component numerically
+	for i := 0; i < len(localParts) && i < len(remoteParts); i++ {
+		l, _ := strconv.Atoi(localParts[i])
+		r, _ := strconv.Atoi(remoteParts[i])
+		if l < r {
+			return -1
+		}
+		if l > r {
+			return 1
+		}
+	}
+
+	// If all compared parts are equal, longer version is greater
+	if len(localParts) < len(remoteParts) {
+		return -1
+	}
+	if len(localParts) > len(remoteParts) {
+		return 1
+	}
+	return 0
+}
+
+// downloadLatestGalleryDl downloads the latest version of gallery-dl from GitHub
+func downloadLatestGalleryDl(client *http.Client, exeName string) error {
+	fmt.Printf("[*] Downloading the latest gallery-dl release from GitHub...\n")
+
+	// Retrieve the latest release info from GitHub
+	releaseURL := "https://api.github.com/repos/mikf/gallery-dl/releases/latest"
+	resp, err := client.Get(releaseURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch the latest release info: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var release struct {
+		Assets []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return fmt.Errorf("failed to parse GitHub API release JSON: %v", err)
+	}
+
+	// Find the Windows executable asset
+	// gallery-dl releases include: gallery-dl.exe, gallery-dl_X.Y.Z.exe, gallery-dl.bin (Linux)
+	var downloadURL string
+	for _, asset := range release.Assets {
+		if strings.EqualFold(asset.Name, exeName) {
+			downloadURL = asset.BrowserDownloadURL
+			break
+		}
+	}
+	if downloadURL == "" {
+		return fmt.Errorf("could not find %s in the latest release assets", exeName)
+	}
+
+	fmt.Printf("[*] Downloading %s...\n", downloadURL)
+
+	// Download the file
+	out, err := os.Create(exeName)
+	if err != nil {
+		return fmt.Errorf("error creating %s: %v", exeName, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	downloadResp, err := client.Get(downloadURL)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %v", exeName, err)
+	}
+	defer func() { _ = downloadResp.Body.Close() }()
+
+	// Copy the response body to the file
+	if _, err := io.Copy(out, downloadResp.Body); err != nil {
+		return fmt.Errorf("failed to write %s to disk: %v", exeName, err)
+	}
+
+	fmt.Println("[*] Successfully downloaded gallery-dl")
+	return nil
+}
+
+// backupGalleryDl backs up the current gallery-dl.exe to gallery-dl.exe.old
+func backupGalleryDl(exeName string) error {
+	oldFileName := exeName + ".old"
+
+	// Delete existing .old file if it exists
+	if _, err := os.Stat(oldFileName); err == nil {
+		fmt.Printf("[*] Removing old backup file: %s\n", oldFileName)
+		if err := os.Remove(oldFileName); err != nil {
+			return fmt.Errorf("failed to delete existing %s: %v", oldFileName, err)
+		}
+	}
+
+	// Rename current exe to .old
+	fmt.Printf("[*] Backing up current %s to %s\n", exeName, oldFileName)
+	if err := os.Rename(exeName, oldFileName); err != nil {
+		return fmt.Errorf("failed to rename %s to %s: %v", exeName, oldFileName, err)
+	}
+
+	return nil
+}
+
+// getOrDownloadGalleryDl checks if gallery-dl.exe is present and downloads if needed.
+// Similar to getOrDownloadYtdlp but for gallery-dl.
+func getOrDownloadGalleryDl(client *http.Client, exeName string) error {
+	// Check if the file already exists
+	if _, err := os.Stat(exeName); err == nil {
+		// File exists - check version against GitHub latest
+		localVersion, err := getGalleryDlVersion(exeName)
+		if err != nil {
+			fmt.Printf("[!] Warning: Could not get local gallery-dl version: %v\n", err)
+			fmt.Printf("[*] Found %s in the current directory. Continuing with existing version.\n", exeName)
+			return nil
+		}
+
+		latestVersion, err := getLatestGalleryDlVersion(client)
+		if err != nil {
+			fmt.Printf("[!] Warning: Could not check for gallery-dl updates: %v\n", err)
+			fmt.Printf("[*] Found %s (version %s). Continuing with existing version.\n", exeName, localVersion)
+			return nil
+		}
+
+		if compareGalleryDlVersions(localVersion, latestVersion) < 0 {
+			// Local version is older than latest
+			fmt.Printf("[*] gallery-dl: Current version: %s, Latest version: %s\n", localVersion, latestVersion)
+			fmt.Print("[*] A newer version of gallery-dl is available. Would you like to update? (Y/n, default is 'Y'): ")
+
+			scanner := bufio.NewScanner(os.Stdin)
+			scanner.Scan()
+			input := strings.TrimSpace(strings.ToLower(scanner.Text()))
+
+			if input == "" || input == "y" || input == "yes" {
+				// Backup and download new version
+				if err := backupGalleryDl(exeName); err != nil {
+					return fmt.Errorf("backup failed: %v", err)
+				}
+
+				if err := downloadLatestGalleryDl(client, exeName); err != nil {
+					// Download failed - try to restore backup
+					fmt.Printf("[!] Download failed: %v\n", err)
+					fmt.Printf("[*] Attempting to restore backup...\n")
+					if restoreErr := os.Rename(exeName+".old", exeName); restoreErr != nil {
+						return fmt.Errorf("download failed and could not restore backup: %v (restore error: %v)", err, restoreErr)
+					}
+					fmt.Printf("[*] Backup restored. Continuing with existing version.\n")
+					return nil
+				}
+			} else {
+				fmt.Printf("[*] Continuing with existing %s (version %s).\n", exeName, localVersion)
+			}
+		} else {
+			fmt.Printf("[*] Found %s (version %s) - up to date.\n", exeName, localVersion)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("error checking for existing %s: %v", exeName, err)
+	}
+
+	// File doesn't exist - download it
+	fmt.Printf("[*] %s not found. Downloading the latest release from GitHub...\n", exeName)
+	return downloadLatestGalleryDl(client, exeName)
+}
+
 // parseFavoriteVideosFromFile reads the given JSON file and returns the list of video entries.
 func parseFavoriteVideosFromFile(jsonFile string, includeLiked bool) ([]VideoEntry, error) {
 	file, err := os.Open(filepath.Clean(jsonFile))
@@ -413,6 +657,7 @@ func sanitizeCollectionName(name string) string {
 // Supports various TikTok URL formats:
 //   - https://www.tiktokv.com/share/video/7600559584901647646/
 //   - https://www.tiktok.com/@user/video/7600559584901647646
+//   - https://www.tiktok.com/@user/photo/7600559584901647646
 //   - https://m.tiktok.com/v/7600559584901647646.html
 func extractVideoID(url string) string {
 	for _, re := range videoIDPatterns {
@@ -421,6 +666,108 @@ func extractVideoID(url string) string {
 		}
 	}
 	return ""
+}
+
+// isPhotoPost checks if a TikTok URL points to a photo/slideshow post by following
+// redirects and checking the final URL. Photo posts redirect to URLs containing "/photo/"
+// while video posts redirect to URLs containing "/video/".
+// Returns: (isPhoto bool, finalURL string, error)
+func isPhotoPost(originalURL string, client *http.Client) (bool, string, error) {
+	// First check if the URL already contains /photo/ (no redirect needed)
+	if strings.Contains(originalURL, "/photo/") {
+		return true, originalURL, nil
+	}
+
+	// Create a request to follow redirects and capture the final URL
+	req, err := http.NewRequest("HEAD", originalURL, nil)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Set a user agent to avoid blocks
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+
+	// Create a client that follows redirects (default behavior)
+	// Use a client with redirect following to get the final URL
+	var finalURL string
+	checkRedirectClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			finalURL = req.URL.String()
+			// Allow up to 10 redirects
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := checkRedirectClient.Do(req)
+	if err != nil {
+		// If we got a final URL from redirects before the error, use it
+		if finalURL != "" && strings.Contains(finalURL, "/photo/") {
+			return true, finalURL, nil
+		}
+		return false, "", fmt.Errorf("failed to fetch URL: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Use the final URL from redirects, or the response URL
+	if finalURL == "" {
+		finalURL = resp.Request.URL.String()
+	}
+
+	// Check if the final URL contains /photo/
+	isPhoto := strings.Contains(finalURL, "/photo/")
+	return isPhoto, finalURL, nil
+}
+
+// detectContentTypes detects whether each URL is a video or photo post.
+// This is done in batches to avoid overwhelming TikTok's servers.
+// Returns a map of URL -> ContentType ("video" or "photo")
+func detectContentTypes(entries []VideoEntry, client *http.Client) map[string]string {
+	contentTypes := make(map[string]string)
+
+	fmt.Printf("[*] Detecting content types for %d URLs...\n", len(entries))
+
+	// Process URLs to detect photos vs videos
+	photoCount := 0
+	videoCount := 0
+	errorCount := 0
+
+	for i, entry := range entries {
+		// Show progress every 50 URLs
+		if (i+1)%50 == 0 || i == len(entries)-1 {
+			fmt.Printf("[*] Checking URL %d/%d...\r", i+1, len(entries))
+		}
+
+		isPhoto, _, err := isPhotoPost(entry.Link, client)
+		if err != nil {
+			// On error, default to video (yt-dlp will handle it)
+			contentTypes[entry.Link] = "video"
+			errorCount++
+			continue
+		}
+
+		if isPhoto {
+			contentTypes[entry.Link] = "photo"
+			photoCount++
+		} else {
+			contentTypes[entry.Link] = "video"
+			videoCount++
+		}
+
+		// Small delay to avoid rate limiting (100ms between requests)
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	fmt.Printf("\n[*] Content type detection complete: %d videos, %d photos", videoCount, photoCount)
+	if errorCount > 0 {
+		fmt.Printf(" (%d detection errors, defaulted to video)", errorCount)
+	}
+	fmt.Println()
+
+	return contentTypes
 }
 
 // parseArchiveFile reads yt-dlp's download archive file and returns
@@ -566,6 +913,35 @@ func getOutputFilename(collection string) string {
 	return "fav_videos.txt"
 }
 
+// getVideoOutputFilename returns the video URL list filename for a collection
+func getVideoOutputFilename(collection string) string {
+	if collection == "liked" {
+		return "liked_videos.txt"
+	}
+	return "fav_videos.txt"
+}
+
+// getPhotoOutputFilename returns the photo URL list filename for a collection
+func getPhotoOutputFilename(collection string) string {
+	if collection == "liked" {
+		return "liked_photos.txt"
+	}
+	return "fav_photos.txt"
+}
+
+// separateEntriesByContentType splits entries into videos and photos based on their ContentType field
+func separateEntriesByContentType(entries []VideoEntry) (videos []VideoEntry, photos []VideoEntry) {
+	for _, entry := range entries {
+		if entry.ContentType == "photo" {
+			photos = append(photos, entry)
+		} else {
+			// Default to video if ContentType is empty or "video"
+			videos = append(videos, entry)
+		}
+	}
+	return
+}
+
 // createCollectionDirectories creates directories for each collection
 func createCollectionDirectories(videoEntries []VideoEntry, organizeByCollection bool) error {
 	if !organizeByCollection {
@@ -586,6 +962,7 @@ func createCollectionDirectories(videoEntries []VideoEntry, organizeByCollection
 }
 
 // writeFavoriteVideosToFile writes the video entries to output files, organized by collection if enabled.
+// Separates videos and photos into different files for processing by yt-dlp and gallery-dl respectively.
 func writeFavoriteVideosToFile(videoEntries []VideoEntry, outputName string, organizeByCollection bool) error {
 	if organizeByCollection {
 		// Create collection directories first
@@ -600,19 +977,56 @@ func writeFavoriteVideosToFile(videoEntries []VideoEntry, outputName string, org
 			collectionGroups[collection] = append(collectionGroups[collection], entry)
 		}
 
-		// Write separate files for each collection with collection-specific filenames
+		// Write separate files for each collection, splitting videos and photos
 		for collection, entries := range collectionGroups {
-			// Use collection-specific filename (fav_videos.txt for favorites, liked_videos.txt for liked)
-			collectionFilename := getOutputFilename(collection)
-			collectionOutputName := filepath.Join(collection, collectionFilename)
-			if err := writeVideoEntriesToFile(entries, collectionOutputName); err != nil {
-				return err
+			videos, photos := separateEntriesByContentType(entries)
+
+			// Write video URLs
+			if len(videos) > 0 {
+				videoFilename := getVideoOutputFilename(collection)
+				videoOutputName := filepath.Join(collection, videoFilename)
+				if err := writeVideoEntriesToFile(videos, videoOutputName); err != nil {
+					return err
+				}
+				fmt.Printf("[*] Extracted %d video URLs to '%s'\n", len(videos), videoOutputName)
 			}
-			fmt.Printf("[*] Extracted %d video URLs to '%s'\n", len(entries), collectionOutputName)
+
+			// Write photo URLs
+			if len(photos) > 0 {
+				photoFilename := getPhotoOutputFilename(collection)
+				photoOutputName := filepath.Join(collection, photoFilename)
+				if err := writeVideoEntriesToFile(photos, photoOutputName); err != nil {
+					return err
+				}
+				fmt.Printf("[*] Extracted %d photo URLs to '%s'\n", len(photos), photoOutputName)
+			}
+
+			// If no photos, still show total for backward compatibility
+			if len(photos) == 0 && len(videos) > 0 {
+				// Already printed above
+			}
 		}
 	} else {
-		// Write all entries to a single file (flat structure)
-		return writeVideoEntriesToFile(videoEntries, outputName)
+		// Flat structure - separate videos and photos
+		videos, photos := separateEntriesByContentType(videoEntries)
+
+		// Write video URLs (use the provided outputName for backward compatibility)
+		if len(videos) > 0 {
+			if err := writeVideoEntriesToFile(videos, outputName); err != nil {
+				return err
+			}
+			fmt.Printf("[*] Extracted %d video URLs to '%s'\n", len(videos), outputName)
+		}
+
+		// Write photo URLs to a separate file in the same directory as the video file
+		if len(photos) > 0 {
+			dir := filepath.Dir(outputName)
+			photoOutputName := filepath.Join(dir, "fav_photos.txt")
+			if err := writeVideoEntriesToFile(photos, photoOutputName); err != nil {
+				return err
+			}
+			fmt.Printf("[*] Extracted %d photo URLs to '%s'\n", len(photos), photoOutputName)
+		}
 	}
 	return nil
 }
@@ -1048,12 +1462,20 @@ func (pr *ProgressRenderer) clearProgress() {
 }
 
 // calculateSessionTotals aggregates totals across all collections
-func calculateSessionTotals(collections []CollectionResult) (attempted, success, failed, skipped int) {
+// Returns: attempted, success, failed, skipped, photosAttempted, photosSuccess, photosFailed
+func calculateSessionTotals(collections []CollectionResult) (attempted, success, failed, skipped, photosAttempted, photosSuccess, photosFailed int) {
 	for _, col := range collections {
 		attempted += col.Attempted
 		success += col.Success
 		failed += col.Failed
 		skipped += col.Skipped
+
+		// Track photo-specific stats
+		if col.ContentType == "photo" {
+			photosAttempted += col.Attempted
+			photosSuccess += col.Success
+			photosFailed += col.Failed
+		}
 	}
 	return
 }
@@ -1066,15 +1488,34 @@ func printSessionSummary(session *DownloadSession) {
 	fmt.Println("                        DOWNLOAD SESSION SUMMARY")
 	fmt.Println(strings.Repeat("=", 80))
 	fmt.Printf("Duration: %s\n", formatDuration(int(duration.Seconds())))
-	fmt.Printf("Total Videos Attempted: %d\n", session.TotalAttempted)
-	fmt.Printf("  ✓ Successfully Downloaded: %d\n", session.TotalSuccess)
+
+	// Calculate video-only stats (total minus photos)
+	videoAttempted := session.TotalAttempted - session.TotalPhotosAttempted
+	videoSuccess := session.TotalSuccess - session.TotalPhotosSuccess
+	videoFailed := session.TotalFailed - session.TotalPhotosFailed
+
+	// Show video stats
+	fmt.Printf("Videos Attempted: %d\n", videoAttempted)
+	fmt.Printf("  ✓ Successfully Downloaded: %d\n", videoSuccess)
 	fmt.Printf("  - Skipped (Already Downloaded): %d\n", session.TotalSkipped)
-	fmt.Printf("  ✗ Failed: %d\n\n", session.TotalFailed)
+	fmt.Printf("  ✗ Failed: %d\n", videoFailed)
+
+	// Show photo stats if any photos were processed
+	if session.TotalPhotosAttempted > 0 {
+		fmt.Printf("\nPhotos Attempted: %d\n", session.TotalPhotosAttempted)
+		fmt.Printf("  ✓ Successfully Downloaded: %d\n", session.TotalPhotosSuccess)
+		fmt.Printf("  ✗ Failed: %d\n", session.TotalPhotosFailed)
+	}
+	fmt.Println()
 
 	if len(session.Collections) > 1 {
 		fmt.Println("Collection Breakdown:")
 		for _, col := range session.Collections {
-			fmt.Printf("  %s:\n", col.Name)
+			contentType := col.ContentType
+			if contentType == "" {
+				contentType = "mixed"
+			}
+			fmt.Printf("  %s (%s):\n", col.Name, contentType)
 			fmt.Printf("    Attempted: %-4d | Success: %-4d | Skipped: %-4d | Failed: %d\n",
 				col.Attempted, col.Success, col.Skipped, col.Failed)
 		}
@@ -1409,6 +1850,159 @@ func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, organ
 	return result, err
 }
 
+// GalleryDlInfo represents metadata from gallery-dl's .json files
+type GalleryDlInfo struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Uploader    string `json:"author"`
+	UploaderID  string `json:"author_id"`
+	Date        string `json:"date"`
+	Category    string `json:"category"`
+	Subcategory string `json:"subcategory"`
+	Filename    string `json:"filename"`
+	Extension   string `json:"extension"`
+	ImageCount  int    `json:"count"`
+}
+
+// parseGalleryDlOutput parses gallery-dl output to detect success/failure
+// gallery-dl outputs: "#<number> <url>" for successful downloads
+// And "ERROR:" or "[error]" for failures
+func parseGalleryDlOutput(lines []string, entries []VideoEntry) (success int, failures []FailureDetail) {
+	// Build video ID to URL map
+	idToURL := make(map[string]string)
+	for _, entry := range entries {
+		id := extractVideoID(entry.Link)
+		if id != "" {
+			idToURL[id] = entry.Link
+		}
+	}
+
+	// Track which video IDs we've seen in success messages
+	seenIDs := make(map[string]bool)
+
+	// Regex patterns for gallery-dl output
+	successPattern := regexp.MustCompile(`^#\d+`)
+	errorPattern := regexp.MustCompile(`(?i)error|failed|\[error\]`)
+	videoIDPattern := regexp.MustCompile(`(\d{19})`) // TikTok video IDs are 19 digits
+
+	for _, line := range lines {
+		// Check for error lines
+		if errorPattern.MatchString(line) {
+			// Extract video ID from error line
+			if matches := videoIDPattern.FindStringSubmatch(line); len(matches) > 1 {
+				videoID := matches[1]
+				if !seenIDs[videoID] {
+					failures = append(failures, FailureDetail{
+						VideoID:      videoID,
+						VideoURL:     idToURL[videoID],
+						ErrorMessage: line,
+						ErrorType:    categorizeError(line),
+					})
+				}
+			}
+			continue
+		}
+
+		// Check for success lines (starts with #number)
+		if successPattern.MatchString(line) {
+			// Try to extract video ID from the line
+			if matches := videoIDPattern.FindStringSubmatch(line); len(matches) > 1 {
+				seenIDs[matches[1]] = true
+			}
+			success++
+		}
+	}
+
+	return success, failures
+}
+
+// runGalleryDl runs gallery-dl to download photo/slideshow posts
+func runGalleryDl(psPrefix, outputDir string, organizeByCollection bool, entries []VideoEntry, cookieFile, cookieFromBrowser string) (*CollectionResult, error) {
+	if len(entries) == 0 {
+		return &CollectionResult{
+			Name:           filepath.Base(outputDir),
+			Attempted:      0,
+			Success:        0,
+			Failed:         0,
+			Skipped:        0,
+			FailureDetails: []FailureDetail{},
+		}, nil
+	}
+
+	collectionName := filepath.Base(outputDir)
+	if collectionName == "." {
+		collectionName = "photos"
+	}
+
+	fmt.Printf("[*] Running gallery-dl for %d photo posts in %s...\n", len(entries), collectionName)
+	cmdStr := fmt.Sprintf("%sgallery-dl.exe", psPrefix)
+
+	// Write URLs to temp file
+	tempFile := filepath.Join(outputDir, "photo_urls_temp.txt")
+	if err := writeVideoEntriesToFile(entries, tempFile); err != nil {
+		return nil, fmt.Errorf("failed to create temp URL file: %v", err)
+	}
+	defer func() { _ = os.Remove(tempFile) }()
+
+	// Build gallery-dl arguments
+	// gallery-dl uses different filename formatting than yt-dlp
+	// Format: {date:%Y%m%d}_{id}_{title:.50}.{extension}
+	filenameFormat := "{date:%Y%m%d}_{id}_{description:.50}.{extension}"
+
+	args := []string{
+		"--input-file", tempFile,
+		"--directory", outputDir,
+		"--filename", filenameFormat,
+		"--write-metadata", // Save metadata JSON for each photo
+	}
+
+	// Add cookie support
+	if cookieFile != "" {
+		args = append(args, "--cookies", cookieFile)
+	}
+	if cookieFromBrowser != "" {
+		args = append(args, "--cookies-from-browser", cookieFromBrowser)
+	}
+
+	// Execute command
+	cmd := exec.Command(cmdStr, args...)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+
+	err := cmd.Run()
+
+	// Parse output
+	combined := combineOutputLines(stdoutBuf.String(), stderrBuf.String())
+	successCount, failures := parseGalleryDlOutput(combined, entries)
+
+	result := &CollectionResult{
+		Name:           collectionName,
+		Attempted:      len(entries),
+		Failed:         len(failures),
+		Success:        successCount,
+		Skipped:        len(entries) - successCount - len(failures),
+		FailureDetails: failures,
+	}
+
+	// Safety check
+	if result.Success < 0 {
+		result.Success = 0
+	}
+	if result.Skipped < 0 {
+		result.Skipped = 0
+	}
+
+	if err != nil || len(failures) > 0 {
+		fmt.Printf("[!] Photo download completed with %d failures out of %d photos.\n",
+			result.Failed, len(entries))
+	} else {
+		fmt.Printf("[*] Successfully downloaded all %d photos.\n", result.Success)
+	}
+
+	return result, err
+}
+
 // HTML template for the visual index browser
 //
 //go:embed templates/index.html
@@ -1468,18 +2062,20 @@ func writeHTMLIndex(dir string, index *CollectionIndex) error {
 }
 
 // generateCollectionIndex creates JSON and HTML indexes for a collection after download.
-// It enriches entries with metadata from yt-dlp's .info.json files and generates
-// both index.json (machine-readable) and index.html (visual browser) files.
+// It enriches entries with metadata from yt-dlp's .info.json files and gallery-dl's .json files,
+// then generates both index.json (machine-readable) and index.html (visual browser) files.
 func generateCollectionIndex(collectionDir string, entries []VideoEntry, failures []FailureDetail) error {
 	collectionName := filepath.Base(collectionDir)
-	fmt.Printf("[*] Generating index for %s (%d videos)...\n", collectionName, len(entries))
-	// 1. Scan for .info.json files in the directory
+	videos, photos := separateEntriesByContentType(entries)
+	fmt.Printf("[*] Generating index for %s (%d videos, %d photos)...\n", collectionName, len(videos), len(photos))
+
+	// 1. Scan for yt-dlp .info.json files in the directory
 	infoFiles, err := filepath.Glob(filepath.Join(collectionDir, "*.info.json"))
 	if err != nil {
 		return fmt.Errorf("collection %q: error scanning for info files: %v", collectionName, err)
 	}
 
-	// 2. Build video ID to info map
+	// 2. Build video ID to info map from yt-dlp metadata
 	infoMap := make(map[string]*YtdlpInfo)
 	for _, f := range infoFiles {
 		info, err := parseInfoJSON(f)
@@ -1489,7 +2085,32 @@ func generateCollectionIndex(collectionDir string, entries []VideoEntry, failure
 		}
 		infoMap[info.ID] = info
 	}
-	fmt.Printf("[*] Found %d metadata files for %s\n", len(infoMap), collectionName)
+
+	// 3. Scan for gallery-dl .json metadata files (for photos)
+	// gallery-dl creates files like: <filename>.json alongside downloaded images
+	galleryDlFiles, _ := filepath.Glob(filepath.Join(collectionDir, "*.json"))
+	photoInfoMap := make(map[string]*GalleryDlInfo)
+	for _, f := range galleryDlFiles {
+		// Skip yt-dlp info files
+		if strings.HasSuffix(f, ".info.json") || f == filepath.Join(collectionDir, "index.json") {
+			continue
+		}
+		data, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		var info GalleryDlInfo
+		if err := json.Unmarshal(data, &info); err != nil {
+			continue
+		}
+		// gallery-dl uses string IDs
+		if info.ID != "" {
+			photoInfoMap[info.ID] = &info
+		}
+	}
+
+	totalMetadataFiles := len(infoMap) + len(photoInfoMap)
+	fmt.Printf("[*] Found %d metadata files for %s\n", totalMetadataFiles, collectionName)
 
 	// 3. Build failure map for quick lookup
 	failureMap := make(map[string]string)
@@ -1514,6 +2135,69 @@ func generateCollectionIndex(collectionDir string, entries []VideoEntry, failure
 			continue
 		}
 
+		// Handle photos differently from videos
+		if enrichedEntries[i].ContentType == "photo" {
+			// Look for gallery-dl metadata
+			if info, ok := photoInfoMap[videoID]; ok {
+				enrichedEntries[i].Description = info.Description
+				enrichedEntries[i].Creator = info.Uploader
+				enrichedEntries[i].CreatorID = info.UploaderID
+				enrichedEntries[i].ImageCount = info.ImageCount
+
+				// Find downloaded image files for this photo post
+				pattern := filepath.Join(collectionDir, fmt.Sprintf("*%s*", videoID))
+				matches, _ := filepath.Glob(pattern)
+				var imageFiles []string
+				for _, match := range matches {
+					ext := strings.ToLower(filepath.Ext(match))
+					if ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".webp" {
+						imageFiles = append(imageFiles, filepath.Base(match))
+					} else if ext == ".m4a" || ext == ".mp3" {
+						enrichedEntries[i].AudioFile = filepath.Base(match)
+					}
+				}
+				enrichedEntries[i].ImageFiles = imageFiles
+				if len(imageFiles) > 0 {
+					enrichedEntries[i].LocalFilename = imageFiles[0]
+					enrichedEntries[i].ThumbnailFile = imageFiles[0]
+					enrichedEntries[i].Downloaded = true
+				} else {
+					enrichedEntries[i].Downloaded = false
+					if errMsg, ok := failureMap[videoID]; ok {
+						enrichedEntries[i].DownloadError = errMsg
+					} else {
+						enrichedEntries[i].DownloadError = "Photo files not found"
+					}
+				}
+			} else {
+				// No gallery-dl metadata, but try to find image files by video ID
+				pattern := filepath.Join(collectionDir, fmt.Sprintf("*%s*", videoID))
+				matches, _ := filepath.Glob(pattern)
+				var imageFiles []string
+				for _, match := range matches {
+					ext := strings.ToLower(filepath.Ext(match))
+					if ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".webp" {
+						imageFiles = append(imageFiles, filepath.Base(match))
+					}
+				}
+				if len(imageFiles) > 0 {
+					enrichedEntries[i].ImageFiles = imageFiles
+					enrichedEntries[i].LocalFilename = imageFiles[0]
+					enrichedEntries[i].ThumbnailFile = imageFiles[0]
+					enrichedEntries[i].Downloaded = true
+				} else {
+					enrichedEntries[i].Downloaded = false
+					if errMsg, ok := failureMap[videoID]; ok {
+						enrichedEntries[i].DownloadError = errMsg
+					} else {
+						enrichedEntries[i].DownloadError = "Photo not downloaded or metadata unavailable"
+					}
+				}
+			}
+			continue
+		}
+
+		// Handle videos (existing logic)
 		if info, ok := infoMap[videoID]; ok {
 			enrichedEntries[i].Title = info.Title
 			enrichedEntries[i].Creator = info.Uploader
@@ -1951,6 +2635,14 @@ func main() {
 		// Not exiting here so you can still generate fav_videos.txt if needed
 	}
 
+	// Also get gallery-dl for photo support
+	galleryDlAvailable := false
+	if err := getOrDownloadGalleryDl(http.DefaultClient, "gallery-dl.exe"); err != nil {
+		fmt.Printf("[!] Warning: gallery-dl not available, photo posts will be skipped: %v\n", err)
+	} else {
+		galleryDlAvailable = true
+	}
+
 	fmt.Print("[*] Would you like to include 'Liked' videos as well? (y/n, default is 'n'): ")
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
@@ -1979,14 +2671,31 @@ func main() {
 
 	fmt.Printf("[*] Successfully loaded %d video entries from '%s'\n", len(videoEntries), config.JSONFile)
 
+	// Detect content types (video vs photo) if gallery-dl is available
+	hasPhotos := false
+	if galleryDlAvailable {
+		contentTypes := detectContentTypes(videoEntries, http.DefaultClient)
+		// Apply content types to entries
+		for i := range videoEntries {
+			if ct, ok := contentTypes[videoEntries[i].Link]; ok {
+				videoEntries[i].ContentType = ct
+				if ct == "photo" {
+					hasPhotos = true
+				}
+			}
+		}
+	}
+
 	// Write video entries to files
 	if err := writeFavoriteVideosToFile(videoEntries, config.OutputName, config.OrganizeByCollection); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	if !config.OrganizeByCollection {
-		fmt.Printf("[*] Extracted %d video URLs to '%s'.\n", len(videoEntries), config.OutputName)
+	// Count videos and photos for display
+	videos, photos := separateEntriesByContentType(videoEntries)
+	if hasPhotos {
+		fmt.Printf("[*] Found %d videos and %d photos\n", len(videos), len(photos))
 	}
 
 	// Construct the recommended yt-dlp command
@@ -2029,43 +2738,84 @@ func main() {
 		}
 
 		if config.OrganizeByCollection {
-			// Run yt-dlp for each collection
+			// Run yt-dlp and gallery-dl for each collection
 			collections := make(map[string]bool)
 			for _, entry := range videoEntries {
 				collections[sanitizeCollectionName(entry.Collection)] = true
 			}
 			for collection := range collections {
-				// Use collection-specific filename
-				collectionFilename := getOutputFilename(collection)
-				collectionOutputName := filepath.Join(collection, collectionFilename)
 				collectionEntries := getEntriesForCollection(videoEntries, collection)
 
-				fmt.Printf("[*] Processing collection: %s\n", collection)
-				result, _ := runYtdlp(psPrefix, collectionOutputName, config.OrganizeByCollection, config.SkipThumbnails, config.DisableResume, config.DisableProgressBar, config.CookieFile, config.CookieFromBrowser, collectionEntries)
+				// Separate videos and photos for this collection
+				collectionVideos, collectionPhotos := separateEntriesByContentType(collectionEntries)
 
-				// Track session results
-				if result != nil {
-					session.Collections = append(session.Collections, *result)
+				var allFailures []FailureDetail
+
+				// Process videos with yt-dlp
+				if len(collectionVideos) > 0 {
+					collectionFilename := getVideoOutputFilename(collection)
+					collectionOutputName := filepath.Join(collection, collectionFilename)
+
+					fmt.Printf("[*] Processing collection: %s (%d videos)\n", collection, len(collectionVideos))
+					result, _ := runYtdlp(psPrefix, collectionOutputName, config.OrganizeByCollection, config.SkipThumbnails, config.DisableResume, config.DisableProgressBar, config.CookieFile, config.CookieFromBrowser, collectionVideos)
+
+					// Track session results
+					if result != nil {
+						result.ContentType = "video"
+						session.Collections = append(session.Collections, *result)
+						allFailures = append(allFailures, result.FailureDetails...)
+					}
 				}
 
-				// Generate index after download completes (pass failures for error details)
-				var failures []FailureDetail
-				if result != nil {
-					failures = result.FailureDetails
+				// Process photos with gallery-dl
+				if len(collectionPhotos) > 0 && galleryDlAvailable {
+					fmt.Printf("[*] Processing collection: %s (%d photos)\n", collection, len(collectionPhotos))
+					result, _ := runGalleryDl(psPrefix, collection, config.OrganizeByCollection, collectionPhotos, config.CookieFile, config.CookieFromBrowser)
+
+					// Track session results
+					if result != nil {
+						result.ContentType = "photo"
+						session.Collections = append(session.Collections, *result)
+						allFailures = append(allFailures, result.FailureDetails...)
+					}
 				}
-				if err := generateCollectionIndex(collection, collectionEntries, failures); err != nil {
+
+				// Generate index after download completes (pass all failures for error details)
+				if err := generateCollectionIndex(collection, collectionEntries, allFailures); err != nil {
 					fmt.Printf("[!] Warning: Failed to generate index for %s: %v\n", collection, err)
 				} else {
 					fmt.Printf("[*] Generated index.html and index.json for %s\n", collection)
 				}
 			}
 		} else {
-			// Flat structure
-			result, _ := runYtdlp(psPrefix, config.OutputName, config.OrganizeByCollection, config.SkipThumbnails, config.DisableResume, config.DisableProgressBar, config.CookieFile, config.CookieFromBrowser, videoEntries)
+			// Flat structure - separate videos and photos
+			flatVideos, flatPhotos := separateEntriesByContentType(videoEntries)
+			var allFailures []FailureDetail
 
-			// Track session results
-			if result != nil {
-				session.Collections = append(session.Collections, *result)
+			// Process videos with yt-dlp
+			if len(flatVideos) > 0 {
+				result, _ := runYtdlp(psPrefix, config.OutputName, config.OrganizeByCollection, config.SkipThumbnails, config.DisableResume, config.DisableProgressBar, config.CookieFile, config.CookieFromBrowser, flatVideos)
+
+				// Track session results
+				if result != nil {
+					result.ContentType = "video"
+					session.Collections = append(session.Collections, *result)
+					allFailures = append(allFailures, result.FailureDetails...)
+				}
+			}
+
+			// Process photos with gallery-dl
+			if len(flatPhotos) > 0 && galleryDlAvailable {
+				fmt.Printf("[*] Processing %d photos with gallery-dl...\n", len(flatPhotos))
+				dir, _ := filepath.Abs(".")
+				result, _ := runGalleryDl(psPrefix, dir, config.OrganizeByCollection, flatPhotos, config.CookieFile, config.CookieFromBrowser)
+
+				// Track session results
+				if result != nil {
+					result.ContentType = "photo"
+					session.Collections = append(session.Collections, *result)
+					allFailures = append(allFailures, result.FailureDetails...)
+				}
 			}
 
 			// Generate index for flat structure in current directory
@@ -2073,11 +2823,7 @@ func main() {
 			if err != nil {
 				dir = "."
 			}
-			var failures []FailureDetail
-			if result != nil {
-				failures = result.FailureDetails
-			}
-			if err := generateCollectionIndex(dir, videoEntries, failures); err != nil {
+			if err := generateCollectionIndex(dir, videoEntries, allFailures); err != nil {
 				fmt.Printf("[!] Warning: Failed to generate index: %v\n", err)
 			} else {
 				fmt.Println("[*] Generated index.html and index.json")
@@ -2086,7 +2832,8 @@ func main() {
 
 		// Finalize session
 		session.EndTime = time.Now()
-		session.TotalAttempted, session.TotalSuccess, session.TotalFailed, session.TotalSkipped =
+		session.TotalAttempted, session.TotalSuccess, session.TotalFailed, session.TotalSkipped,
+			session.TotalPhotosAttempted, session.TotalPhotosSuccess, session.TotalPhotosFailed =
 			calculateSessionTotals(session.Collections)
 
 		// Print summary

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -216,19 +216,6 @@ type Config struct {
 	CookieFromBrowser    string // Browser name (chrome, firefox, edge, safari, etc.)
 }
 
-// isFileOlderThan30Days checks if a file's modification time is more than 30 days old
-func isFileOlderThan30Days(path string) (bool, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false, err
-	}
-
-	modTime := info.ModTime()
-	thirtyDaysAgo := time.Now().AddDate(0, 0, -30)
-
-	return modTime.Before(thirtyDaysAgo), nil
-}
-
 // getYtdlpVersion runs yt-dlp --version and returns the version string (e.g., "2026.01.29")
 func getYtdlpVersion(exePath string) (string, error) {
 	// Use explicit relative path for Go 1.19+ security (cannot run executables from current dir without ./)
@@ -1088,14 +1075,6 @@ func parseInfoJSON(infoPath string) (*YtdlpInfo, error) {
 		return nil, err
 	}
 	return &info, nil
-}
-
-// getOutputFilename returns the appropriate URL list filename for a collection
-func getOutputFilename(collection string) string {
-	if collection == "liked" {
-		return "liked_videos.txt"
-	}
-	return "fav_videos.txt"
 }
 
 // getVideoOutputFilename returns the video URL list filename for a collection

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -2226,6 +2226,23 @@ func writeHTMLIndex(dir string, index *CollectionIndex) error {
 }
 
 // generateCollectionIndex creates JSON and HTML indexes for a collection after download.
+// scanPhotoFiles finds downloaded image files and an audio file for a photo post
+// by globbing the collection directory for files matching the video ID.
+func scanPhotoFiles(collectionDir, videoID string) (imageFiles []string, audioFile string) {
+	pattern := filepath.Join(collectionDir, fmt.Sprintf("*%s*", videoID))
+	matches, _ := filepath.Glob(pattern)
+	for _, match := range matches {
+		ext := strings.ToLower(filepath.Ext(match))
+		switch ext {
+		case ".jpg", ".jpeg", ".png", ".webp":
+			imageFiles = append(imageFiles, filepath.Base(match))
+		case ".m4a", ".mp3":
+			audioFile = filepath.Base(match)
+		}
+	}
+	return
+}
+
 // It enriches entries with metadata from yt-dlp's .info.json files and gallery-dl's .json files,
 // then generates both index.json (machine-readable) and index.html (visual browser) files.
 func generateCollectionIndex(collectionDir string, entries []VideoEntry, failures []FailureDetail) error {
@@ -2308,19 +2325,9 @@ func generateCollectionIndex(collectionDir string, entries []VideoEntry, failure
 				enrichedEntries[i].CreatorID = info.UploaderID
 				enrichedEntries[i].ImageCount = info.ImageCount
 
-				// Find downloaded image files for this photo post
-				pattern := filepath.Join(collectionDir, fmt.Sprintf("*%s*", videoID))
-				matches, _ := filepath.Glob(pattern)
-				var imageFiles []string
-				for _, match := range matches {
-					ext := strings.ToLower(filepath.Ext(match))
-					switch ext {
-					case ".jpg", ".jpeg", ".png", ".webp":
-						imageFiles = append(imageFiles, filepath.Base(match))
-					case ".m4a", ".mp3":
-						enrichedEntries[i].AudioFile = filepath.Base(match)
-					}
-				}
+				// Find downloaded image and audio files for this photo post
+				imageFiles, audioFile := scanPhotoFiles(collectionDir, videoID)
+				enrichedEntries[i].AudioFile = audioFile
 				enrichedEntries[i].ImageFiles = imageFiles
 				if len(imageFiles) > 0 {
 					enrichedEntries[i].LocalFilename = imageFiles[0]
@@ -2336,15 +2343,8 @@ func generateCollectionIndex(collectionDir string, entries []VideoEntry, failure
 				}
 			} else {
 				// No gallery-dl metadata, but try to find image files by video ID
-				pattern := filepath.Join(collectionDir, fmt.Sprintf("*%s*", videoID))
-				matches, _ := filepath.Glob(pattern)
-				var imageFiles []string
-				for _, match := range matches {
-					ext := strings.ToLower(filepath.Ext(match))
-					if ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".webp" {
-						imageFiles = append(imageFiles, filepath.Base(match))
-					}
-				}
+				imageFiles, audioFile := scanPhotoFiles(collectionDir, videoID)
+				enrichedEntries[i].AudioFile = audioFile
 				if len(imageFiles) > 0 {
 					enrichedEntries[i].ImageFiles = imageFiles
 					enrichedEntries[i].LocalFilename = imageFiles[0]

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -807,7 +807,7 @@ func isPhotoPost(originalURL string, client *http.Client) (bool, string, error) 
 // This is done in batches to avoid overwhelming TikTok's servers.
 // Uses the provided cache to skip network requests for already-known URLs.
 // Returns a map of URL -> ContentType ("video" or "photo") including both cached and newly detected entries.
-func detectContentTypes(entries []VideoEntry, client *http.Client, cache map[string]string) map[string]string {
+func detectContentTypes(entries []VideoEntry, client *http.Client, cache map[string]string, disableProgressBar bool) map[string]string {
 	contentTypes := make(map[string]string)
 
 	// Separate cached from uncached entries
@@ -843,15 +843,25 @@ func detectContentTypes(entries []VideoEntry, client *http.Client, cache map[str
 		fmt.Printf("[*] Detecting content types for %d URLs...\n", len(entries))
 	}
 
+	// Set up progress bar if supported and not disabled
+	useProgressBar := !disableProgressBar && supportsANSI()
+	renderer := &ProgressRenderer{
+		enabled: useProgressBar,
+	}
+
 	// Process only uncached URLs to detect photos vs videos
 	photoCount := 0
 	videoCount := 0
 	errorCount := 0
 
 	for i, entry := range uncached {
-		// Show progress every 50 URLs
-		if (i+1)%50 == 0 || i == len(uncached)-1 {
-			fmt.Printf("[*] Checking URL %d/%d...\r", i+1, len(uncached))
+		if useProgressBar {
+			renderer.renderDetectionProgress(i+1, len(uncached), videoCount, photoCount, errorCount)
+		} else {
+			// Fallback: show progress every 50 URLs
+			if (i+1)%50 == 0 || i == len(uncached)-1 {
+				fmt.Printf("[*] Checking URL %d/%d...\r", i+1, len(uncached))
+			}
 		}
 
 		isPhoto, _, err := isPhotoPost(entry.Link, client)
@@ -874,7 +884,15 @@ func detectContentTypes(entries []VideoEntry, client *http.Client, cache map[str
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	fmt.Printf("\n[*] Content type detection complete: %d videos, %d photos", videoCount, photoCount)
+	// Render final state and clear progress bar
+	if useProgressBar {
+		renderer.renderDetectionProgress(len(uncached), len(uncached), videoCount, photoCount, errorCount)
+		renderer.clearProgress()
+	} else {
+		fmt.Println()
+	}
+
+	fmt.Printf("[*] Content type detection complete: %d videos, %d photos", videoCount, photoCount)
 	if errorCount > 0 {
 		fmt.Printf(" (%d detection errors, defaulted to video)", errorCount)
 	}
@@ -1587,6 +1605,67 @@ func (pr *ProgressRenderer) renderProgress(state *ProgressState) {
 		reset,
 		red,
 		state.FailureCount,
+		reset,
+	)
+
+	// Clear previous line if it was longer
+	if len(line) < pr.lastLineLen {
+		line += strings.Repeat(" ", pr.lastLineLen-len(line))
+	}
+	pr.lastLineLen = len(line)
+
+	// Print progress (using \r to overwrite current line)
+	_, _ = fmt.Fprint(out, line)
+}
+
+// renderDetectionProgress renders a progress bar for content type detection.
+// Format: "Detecting content types (X/Y) | ████░░░ Z% | Videos: N | Photos: N | Errors: N"
+func (pr *ProgressRenderer) renderDetectionProgress(current, total, videoCount, photoCount, errorCount int) {
+	if !pr.enabled {
+		return
+	}
+
+	// Default to stdout if no writer specified
+	out := pr.writer
+	if out == nil {
+		out = os.Stdout
+	}
+
+	// Calculate percentage
+	percentage := 0.0
+	if total > 0 {
+		percentage = float64(current) / float64(total) * 100
+	}
+
+	// Create progress bar (20 characters wide)
+	barWidth := 20
+	filledWidth := int(float64(barWidth) * percentage / 100)
+	if filledWidth > barWidth {
+		filledWidth = barWidth
+	}
+
+	bar := strings.Repeat("█", filledWidth) + strings.Repeat("░", barWidth-filledWidth)
+
+	// Color codes
+	green := "\033[32m"
+	cyan := "\033[36m"
+	red := "\033[31m"
+	reset := "\033[0m"
+
+	// Build progress line
+	line := fmt.Sprintf("\rDetecting content types (%d/%d) | %s %.1f%% | %sVideos: %d%s | %sPhotos: %d%s | %sErrors: %d%s",
+		current,
+		total,
+		bar,
+		percentage,
+		green,
+		videoCount,
+		reset,
+		cyan,
+		photoCount,
+		reset,
+		red,
+		errorCount,
 		reset,
 	)
 
@@ -2833,7 +2912,7 @@ func main() {
 	cacheFilePath := "content_types_cache.json"
 	if galleryDlAvailable {
 		cache := loadContentTypeCache(cacheFilePath)
-		contentTypes := detectContentTypes(videoEntries, http.DefaultClient, cache)
+		contentTypes := detectContentTypes(videoEntries, http.DefaultClient, cache, config.DisableProgressBar)
 		// Save updated cache to disk
 		if err := saveContentTypeCache(cacheFilePath, contentTypes); err != nil {
 			fmt.Printf("[!] Warning: could not save content type cache: %v\n", err)

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -222,6 +222,87 @@ func isFileOlderThan30Days(path string) (bool, error) {
 	return modTime.Before(thirtyDaysAgo), nil
 }
 
+// getYtdlpVersion runs yt-dlp --version and returns the version string (e.g., "2026.01.29")
+func getYtdlpVersion(exePath string) (string, error) {
+	// Use explicit relative path for Go 1.19+ security (cannot run executables from current dir without ./)
+	cmd := exec.Command("."+string(filepath.Separator)+exePath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run %s --version: %v", exePath, err)
+	}
+	version := strings.TrimSpace(string(output))
+	if version == "" {
+		return "", fmt.Errorf("yt-dlp --version returned empty output")
+	}
+	return version, nil
+}
+
+// getLatestYtdlpVersion fetches the latest yt-dlp version from GitHub releases
+// It uses the redirect from /releases/latest to determine the version tag
+func getLatestYtdlpVersion(client *http.Client) (string, error) {
+	// Create a client that doesn't follow redirects so we can capture the Location header
+	checkRedirect := client.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse // Don't follow redirects
+	}
+	defer func() { client.CheckRedirect = checkRedirect }()
+
+	resp, err := client.Get("https://github.com/yt-dlp/yt-dlp/releases/latest")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch GitHub releases: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// GitHub returns 302 redirect to /releases/tag/YYYY.MM.DD
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusMovedPermanently {
+		return "", fmt.Errorf("unexpected response status: %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", fmt.Errorf("no redirect location in response")
+	}
+
+	// Extract version from URL like https://github.com/yt-dlp/yt-dlp/releases/tag/2026.01.29
+	parts := strings.Split(location, "/tag/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected redirect URL format: %s", location)
+	}
+
+	version := strings.TrimSpace(parts[1])
+	if version == "" {
+		return "", fmt.Errorf("empty version in redirect URL")
+	}
+
+	return version, nil
+}
+
+// compareVersions compares two yt-dlp version strings in YYYY.MM.DD format
+// Returns: -1 if local < remote (needs update), 0 if equal, 1 if local > remote
+func compareVersions(local, remote string) int {
+	// Parse versions - yt-dlp uses YYYY.MM.DD format
+	// Simple string comparison works since format is consistent and zero-padded
+	if local == remote {
+		return 0
+	}
+	if local < remote {
+		return -1
+	}
+	return 1
+}
+
+// updateYtdlp runs yt-dlp --update to self-update the binary
+func updateYtdlp(exePath string) error {
+	fmt.Println("[*] Running yt-dlp --update...")
+	// Use explicit relative path for Go 1.19+ security
+	cmd := exec.Command("."+string(filepath.Separator)+exePath, "--update")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("yt-dlp --update failed: %v", err)
+	}
+	return nil
+}
 // promptForUpdate asks the user if they want to update yt-dlp.exe
 // Returns true if user wants to update (default is yes)
 func promptForUpdate() bool {
@@ -371,7 +452,8 @@ func getOrDownloadYtdlp(client *http.Client, exeName string) error {
 
 // getGalleryDlVersion runs gallery-dl --version and returns the version string
 func getGalleryDlVersion(exePath string) (string, error) {
-	cmd := exec.Command(exePath, "--version")
+	// Use explicit relative path for Go 1.19+ security
+	cmd := exec.Command("."+string(filepath.Separator)+exePath, "--version")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to run %s --version: %v", exePath, err)
@@ -687,22 +769,21 @@ func isPhotoPost(originalURL string, client *http.Client) (bool, string, error) 
 	// Set a user agent to avoid blocks
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
 
-	// Create a client that follows redirects (default behavior)
-	// Use a client with redirect following to get the final URL
+	// Use the injected client but configure redirect handling to capture the final URL
+	// Save original redirect policy and restore after
+	originalCheckRedirect := client.CheckRedirect
 	var finalURL string
-	checkRedirectClient := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			finalURL = req.URL.String()
-			// Allow up to 10 redirects
-			if len(via) >= 10 {
-				return fmt.Errorf("too many redirects")
-			}
-			return nil
-		},
-		Timeout: 30 * time.Second,
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		finalURL = req.URL.String()
+		// Allow up to 10 redirects
+		if len(via) >= 10 {
+			return fmt.Errorf("too many redirects")
+		}
+		return nil
 	}
+	defer func() { client.CheckRedirect = originalCheckRedirect }()
 
-	resp, err := checkRedirectClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		// If we got a final URL from redirects before the error, use it
 		if finalURL != "" && strings.Contains(finalURL, "/photo/") {

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -216,6 +216,192 @@ type Config struct {
 	CookieFromBrowser    string // Browser name (chrome, firefox, edge, safari, etc.)
 }
 
+
+// ToolConfig defines how to manage an external tool (yt-dlp, gallery-dl, etc.)
+type ToolConfig struct {
+	Name            string                                       // Display name (e.g., "yt-dlp")
+	ExeName         string                                       // Executable filename (e.g., "yt-dlp.exe")
+	GitHubRepo      string                                       // GitHub repo path (e.g., "yt-dlp/yt-dlp")
+	GetVersion      func(exePath string) (string, error)         // Get local version
+	CompareVersions func(local, remote string) int               // Compare versions
+	SelfUpdate      func(exePath string) error                   // Self-update command (nil if unsupported)
+	StripVPrefix    bool                                         // Strip "v" prefix from GitHub release tag
+}
+
+// backupExe backs up the current executable to .old
+func backupExe(exeName string) error {
+	oldFileName := exeName + ".old"
+
+	// Delete existing .old file if it exists
+	if _, err := os.Stat(oldFileName); err == nil {
+		fmt.Printf("[*] Removing old backup file: %s\n", oldFileName)
+		if err := os.Remove(oldFileName); err != nil {
+			return fmt.Errorf("failed to delete existing %s: %v", oldFileName, err)
+		}
+	}
+
+	// Rename current exe to .old
+	fmt.Printf("[*] Backing up current %s to %s\n", exeName, oldFileName)
+	if err := os.Rename(exeName, oldFileName); err != nil {
+		return fmt.Errorf("failed to rename %s to %s: %v", exeName, oldFileName, err)
+	}
+
+	return nil
+}
+
+// downloadLatestRelease downloads the latest version of a tool from GitHub releases
+func downloadLatestRelease(client *http.Client, tool *ToolConfig) error {
+	fmt.Printf("[*] Downloading the latest %s release from GitHub...\n", tool.Name)
+
+	releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", tool.GitHubRepo)
+	resp, err := client.Get(releaseURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch the latest release info: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var release struct {
+		Assets []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return fmt.Errorf("failed to parse GitHub API release JSON: %v", err)
+	}
+
+	var downloadURL string
+	for _, asset := range release.Assets {
+		if strings.EqualFold(asset.Name, tool.ExeName) {
+			downloadURL = asset.BrowserDownloadURL
+			break
+		}
+	}
+	if downloadURL == "" {
+		return fmt.Errorf("could not find %s in the latest release assets", tool.ExeName)
+	}
+
+	fmt.Printf("[*] Downloading %s...\n", downloadURL)
+
+	out, err := os.Create(tool.ExeName)
+	if err != nil {
+		return fmt.Errorf("error creating %s: %v", tool.ExeName, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	downloadResp, err := client.Get(downloadURL)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %v", tool.ExeName, err)
+	}
+	defer func() { _ = downloadResp.Body.Close() }()
+
+	if _, err := io.Copy(out, downloadResp.Body); err != nil {
+		return fmt.Errorf("failed to write %s to disk: %v", tool.ExeName, err)
+	}
+
+	fmt.Printf("[*] Successfully downloaded %s\n", tool.Name)
+	return nil
+}
+
+// getLatestVersion fetches the latest version of a tool from GitHub releases
+func getLatestVersion(client *http.Client, tool *ToolConfig) (string, error) {
+	checkRedirect := client.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer func() { client.CheckRedirect = checkRedirect }()
+
+	url := fmt.Sprintf("https://github.com/%s/releases/latest", tool.GitHubRepo)
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch GitHub releases: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusMovedPermanently {
+		return "", fmt.Errorf("unexpected response status: %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", fmt.Errorf("no redirect location in response")
+	}
+
+	parts := strings.Split(location, "/tag/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("unexpected redirect URL format: %s", location)
+	}
+
+	version := strings.TrimSpace(parts[1])
+	if tool.StripVPrefix {
+		version = strings.TrimPrefix(version, "v")
+	}
+	if version == "" {
+		return "", fmt.Errorf("empty version in redirect URL")
+	}
+
+	return version, nil
+}
+
+// getOrDownloadTool checks if a tool is present, offers updates, or downloads it
+func getOrDownloadTool(client *http.Client, tool *ToolConfig) error {
+	if _, err := os.Stat(tool.ExeName); err == nil {
+		localVersion, err := tool.GetVersion(tool.ExeName)
+		if err != nil {
+			fmt.Printf("[!] Warning: Could not get local %s version: %v\n", tool.Name, err)
+			fmt.Printf("[*] Found %s in the current directory. Continuing with existing version.\n", tool.ExeName)
+			return nil
+		}
+
+		latestVersion, err := getLatestVersion(client, tool)
+		if err != nil {
+			fmt.Printf("[!] Warning: Could not check for %s updates: %v\n", tool.Name, err)
+			fmt.Printf("[*] Found %s (version %s). Continuing with existing version.\n", tool.ExeName, localVersion)
+			return nil
+		}
+
+		if tool.CompareVersions(localVersion, latestVersion) < 0 {
+			fmt.Printf("[*] %s: Current version: %s, Latest version: %s\n", tool.Name, localVersion, latestVersion)
+			if promptForUpdate() {
+				// Try self-update first if supported
+				if tool.SelfUpdate != nil {
+					if err := tool.SelfUpdate(tool.ExeName); err != nil {
+						fmt.Printf("[!] Self-update failed: %v\n", err)
+						fmt.Printf("[*] Trying manual download as fallback...\n")
+					} else {
+						return nil
+					}
+				}
+
+				// Manual download (backup + download)
+				if err := backupExe(tool.ExeName); err != nil {
+					return fmt.Errorf("backup failed: %v", err)
+				}
+
+				if err := downloadLatestRelease(client, tool); err != nil {
+					fmt.Printf("[!] Download failed: %v\n", err)
+					fmt.Printf("[*] Attempting to restore backup...\n")
+					if restoreErr := os.Rename(tool.ExeName+".old", tool.ExeName); restoreErr != nil {
+						return fmt.Errorf("download failed and could not restore backup: %v (restore error: %v)", err, restoreErr)
+					}
+					fmt.Printf("[*] Backup restored. Continuing with existing version.\n")
+					return nil
+				}
+			} else {
+				fmt.Printf("[*] Continuing with existing %s (version %s).\n", tool.ExeName, localVersion)
+			}
+		} else {
+			fmt.Printf("[*] Found %s (version %s) - up to date.\n", tool.ExeName, localVersion)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("error checking for existing %s: %v", tool.ExeName, err)
+	}
+
+	fmt.Printf("[*] %s not found. Downloading the latest release from GitHub...\n", tool.ExeName)
+	return downloadLatestRelease(client, tool)
+}
+
 // getYtdlpVersion runs yt-dlp --version and returns the version string (e.g., "2026.01.29")
 func getYtdlpVersion(exePath string) (string, error) {
 	// Use explicit relative path for Go 1.19+ security (cannot run executables from current dir without ./)
@@ -228,46 +414,6 @@ func getYtdlpVersion(exePath string) (string, error) {
 	if version == "" {
 		return "", fmt.Errorf("yt-dlp --version returned empty output")
 	}
-	return version, nil
-}
-
-// getLatestYtdlpVersion fetches the latest yt-dlp version from GitHub releases
-// It uses the redirect from /releases/latest to determine the version tag
-func getLatestYtdlpVersion(client *http.Client) (string, error) {
-	// Create a client that doesn't follow redirects so we can capture the Location header
-	checkRedirect := client.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse // Don't follow redirects
-	}
-	defer func() { client.CheckRedirect = checkRedirect }()
-
-	resp, err := client.Get("https://github.com/yt-dlp/yt-dlp/releases/latest")
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch GitHub releases: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// GitHub returns 302 redirect to /releases/tag/YYYY.MM.DD
-	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusMovedPermanently {
-		return "", fmt.Errorf("unexpected response status: %d", resp.StatusCode)
-	}
-
-	location := resp.Header.Get("Location")
-	if location == "" {
-		return "", fmt.Errorf("no redirect location in response")
-	}
-
-	// Extract version from URL like https://github.com/yt-dlp/yt-dlp/releases/tag/2026.01.29
-	parts := strings.Split(location, "/tag/")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("unexpected redirect URL format: %s", location)
-	}
-
-	version := strings.TrimSpace(parts[1])
-	if version == "" {
-		return "", fmt.Errorf("empty version in redirect URL")
-	}
-
 	return version, nil
 }
 
@@ -314,136 +460,6 @@ func promptForUpdate() bool {
 	return false
 }
 
-// backupYtdlp backs up the current yt-dlp.exe to yt-dlp.exe.old
-// Deletes existing .old file if it exists
-func backupYtdlp(exeName string) error {
-	oldFileName := exeName + ".old"
-
-	// Delete existing .old file if it exists
-	if _, err := os.Stat(oldFileName); err == nil {
-		fmt.Printf("[*] Removing old backup file: %s\n", oldFileName)
-		if err := os.Remove(oldFileName); err != nil {
-			return fmt.Errorf("failed to delete existing %s: %v", oldFileName, err)
-		}
-	}
-
-	// Rename current exe to .old
-	fmt.Printf("[*] Backing up current %s to %s\n", exeName, oldFileName)
-	if err := os.Rename(exeName, oldFileName); err != nil {
-		return fmt.Errorf("failed to rename %s to %s: %v", exeName, oldFileName, err)
-	}
-
-	return nil
-}
-
-// downloadLatestYtdlp downloads the latest version of yt-dlp from GitHub
-func downloadLatestYtdlp(client *http.Client, exeName string) error {
-	fmt.Printf("[*] Downloading the latest release from GitHub...\n")
-
-	// 1. Retrieve the latest release info from GitHub
-	releaseURL := "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest"
-	resp, err := client.Get(releaseURL)
-	if err != nil {
-		return fmt.Errorf("failed to fetch the latest release info: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var release struct {
-		Assets []struct {
-			Name               string `json:"name"`
-			BrowserDownloadURL string `json:"browser_download_url"`
-		} `json:"assets"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return fmt.Errorf("failed to parse GitHub API release JSON: %v", err)
-	}
-
-	// 2. Find the asset with name "yt-dlp.exe"
-	var downloadURL string
-	for _, asset := range release.Assets {
-		if strings.EqualFold(asset.Name, exeName) {
-			downloadURL = asset.BrowserDownloadURL
-			break
-		}
-	}
-	if downloadURL == "" {
-		return fmt.Errorf("could not find %s in the latest release assets", exeName)
-	}
-
-	fmt.Printf("[*] Downloading %s...\n", downloadURL)
-
-	// 3. Download the file
-	out, err := os.Create(exeName)
-	if err != nil {
-		return fmt.Errorf("error creating %s: %v", exeName, err)
-	}
-	defer func() { _ = out.Close() }()
-
-	downloadResp, err := client.Get(downloadURL)
-	if err != nil {
-		return fmt.Errorf("failed to download %s: %v", exeName, err)
-	}
-	defer func() { _ = downloadResp.Body.Close() }()
-
-	// 4. Copy the response body to the file
-	if _, err := io.Copy(out, downloadResp.Body); err != nil {
-		return fmt.Errorf("failed to write %s to disk: %v", exeName, err)
-	}
-
-	fmt.Println("[*] Successfully downloaded yt-dlp")
-	return nil
-}
-
-// getOrDownloadYtdlp checks if yt-dlp.exe is present in the current directory.
-// If not, it downloads the latest version from GitHub.
-// If it exists but is older than 30 days, prompts user to update.
-// Accepts an *http.Client so we can mock the download in tests.
-func getOrDownloadYtdlp(client *http.Client, exeName string) error {
-	// Check if the file already exists
-	if _, err := os.Stat(exeName); err == nil {
-		// File exists - check if it's older than 30 days
-		isOld, err := isFileOlderThan30Days(exeName)
-		if err != nil {
-			fmt.Printf("[!] Warning: Could not check file age: %v\n", err)
-			fmt.Printf("[*] Found %s in the current directory. Continuing with existing version.\n", exeName)
-			return nil
-		}
-
-		if isOld {
-			// Prompt user for update
-			if promptForUpdate() {
-				// User wants to update - backup current version
-				if err := backupYtdlp(exeName); err != nil {
-					return fmt.Errorf("backup failed: %v", err)
-				}
-
-				// Download new version
-				if err := downloadLatestYtdlp(client, exeName); err != nil {
-					// Download failed - try to restore backup
-					fmt.Printf("[!] Download failed: %v\n", err)
-					fmt.Printf("[*] Attempting to restore backup...\n")
-					if restoreErr := os.Rename(exeName+".old", exeName); restoreErr != nil {
-						return fmt.Errorf("download failed and could not restore backup: %v (restore error: %v)", err, restoreErr)
-					}
-					fmt.Printf("[*] Backup restored. Continuing with existing version.\n")
-					return nil
-				}
-			} else {
-				fmt.Printf("[*] Continuing with existing %s.\n", exeName)
-			}
-		} else {
-			fmt.Printf("[*] Found %s in the current directory. Skipping download.\n", exeName)
-		}
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("error checking for existing %s: %v", exeName, err)
-	}
-
-	// File doesn't exist - download it
-	fmt.Printf("[*] %s not found. Downloading the latest release from GitHub...\n", exeName)
-	return downloadLatestYtdlp(client, exeName)
-}
-
 // getGalleryDlVersion runs gallery-dl --version and returns the version string
 func getGalleryDlVersion(exePath string) (string, error) {
 	// Use explicit relative path for Go 1.19+ security
@@ -462,47 +478,6 @@ func getGalleryDlVersion(exePath string) (string, error) {
 	if version == "" {
 		return "", fmt.Errorf("gallery-dl --version returned empty output")
 	}
-	return version, nil
-}
-
-// getLatestGalleryDlVersion fetches the latest gallery-dl version from GitHub releases
-func getLatestGalleryDlVersion(client *http.Client) (string, error) {
-	// Create a client that doesn't follow redirects so we can capture the Location header
-	checkRedirect := client.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse // Don't follow redirects
-	}
-	defer func() { client.CheckRedirect = checkRedirect }()
-
-	resp, err := client.Get("https://github.com/mikf/gallery-dl/releases/latest")
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch GitHub releases: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// GitHub returns 302 redirect to /releases/tag/vX.Y.Z
-	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusMovedPermanently {
-		return "", fmt.Errorf("unexpected response status: %d", resp.StatusCode)
-	}
-
-	location := resp.Header.Get("Location")
-	if location == "" {
-		return "", fmt.Errorf("no redirect location in response")
-	}
-
-	// Extract version from URL like https://github.com/mikf/gallery-dl/releases/tag/v1.28.0
-	parts := strings.Split(location, "/tag/")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("unexpected redirect URL format: %s", location)
-	}
-
-	version := strings.TrimSpace(parts[1])
-	// Remove 'v' prefix if present (gallery-dl uses v1.28.0 format)
-	version = strings.TrimPrefix(version, "v")
-	if version == "" {
-		return "", fmt.Errorf("empty version in redirect URL")
-	}
-
 	return version, nil
 }
 
@@ -533,147 +508,6 @@ func compareGalleryDlVersions(local, remote string) int {
 		return 1
 	}
 	return 0
-}
-
-// downloadLatestGalleryDl downloads the latest version of gallery-dl from GitHub
-func downloadLatestGalleryDl(client *http.Client, exeName string) error {
-	fmt.Printf("[*] Downloading the latest gallery-dl release from GitHub...\n")
-
-	// Retrieve the latest release info from GitHub
-	releaseURL := "https://api.github.com/repos/mikf/gallery-dl/releases/latest"
-	resp, err := client.Get(releaseURL)
-	if err != nil {
-		return fmt.Errorf("failed to fetch the latest release info: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var release struct {
-		Assets []struct {
-			Name               string `json:"name"`
-			BrowserDownloadURL string `json:"browser_download_url"`
-		} `json:"assets"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return fmt.Errorf("failed to parse GitHub API release JSON: %v", err)
-	}
-
-	// Find the Windows executable asset
-	// gallery-dl releases include: gallery-dl.exe, gallery-dl_X.Y.Z.exe, gallery-dl.bin (Linux)
-	var downloadURL string
-	for _, asset := range release.Assets {
-		if strings.EqualFold(asset.Name, exeName) {
-			downloadURL = asset.BrowserDownloadURL
-			break
-		}
-	}
-	if downloadURL == "" {
-		return fmt.Errorf("could not find %s in the latest release assets", exeName)
-	}
-
-	fmt.Printf("[*] Downloading %s...\n", downloadURL)
-
-	// Download the file
-	out, err := os.Create(exeName)
-	if err != nil {
-		return fmt.Errorf("error creating %s: %v", exeName, err)
-	}
-	defer func() { _ = out.Close() }()
-
-	downloadResp, err := client.Get(downloadURL)
-	if err != nil {
-		return fmt.Errorf("failed to download %s: %v", exeName, err)
-	}
-	defer func() { _ = downloadResp.Body.Close() }()
-
-	// Copy the response body to the file
-	if _, err := io.Copy(out, downloadResp.Body); err != nil {
-		return fmt.Errorf("failed to write %s to disk: %v", exeName, err)
-	}
-
-	fmt.Println("[*] Successfully downloaded gallery-dl")
-	return nil
-}
-
-// backupGalleryDl backs up the current gallery-dl.exe to gallery-dl.exe.old
-func backupGalleryDl(exeName string) error {
-	oldFileName := exeName + ".old"
-
-	// Delete existing .old file if it exists
-	if _, err := os.Stat(oldFileName); err == nil {
-		fmt.Printf("[*] Removing old backup file: %s\n", oldFileName)
-		if err := os.Remove(oldFileName); err != nil {
-			return fmt.Errorf("failed to delete existing %s: %v", oldFileName, err)
-		}
-	}
-
-	// Rename current exe to .old
-	fmt.Printf("[*] Backing up current %s to %s\n", exeName, oldFileName)
-	if err := os.Rename(exeName, oldFileName); err != nil {
-		return fmt.Errorf("failed to rename %s to %s: %v", exeName, oldFileName, err)
-	}
-
-	return nil
-}
-
-// getOrDownloadGalleryDl checks if gallery-dl.exe is present and downloads if needed.
-// Similar to getOrDownloadYtdlp but for gallery-dl.
-func getOrDownloadGalleryDl(client *http.Client, exeName string) error {
-	// Check if the file already exists
-	if _, err := os.Stat(exeName); err == nil {
-		// File exists - check version against GitHub latest
-		localVersion, err := getGalleryDlVersion(exeName)
-		if err != nil {
-			fmt.Printf("[!] Warning: Could not get local gallery-dl version: %v\n", err)
-			fmt.Printf("[*] Found %s in the current directory. Continuing with existing version.\n", exeName)
-			return nil
-		}
-
-		latestVersion, err := getLatestGalleryDlVersion(client)
-		if err != nil {
-			fmt.Printf("[!] Warning: Could not check for gallery-dl updates: %v\n", err)
-			fmt.Printf("[*] Found %s (version %s). Continuing with existing version.\n", exeName, localVersion)
-			return nil
-		}
-
-		if compareGalleryDlVersions(localVersion, latestVersion) < 0 {
-			// Local version is older than latest
-			fmt.Printf("[*] gallery-dl: Current version: %s, Latest version: %s\n", localVersion, latestVersion)
-			fmt.Print("[*] A newer version of gallery-dl is available. Would you like to update? (Y/n, default is 'Y'): ")
-
-			scanner := bufio.NewScanner(os.Stdin)
-			scanner.Scan()
-			input := strings.TrimSpace(strings.ToLower(scanner.Text()))
-
-			if input == "" || input == "y" || input == "yes" {
-				// Backup and download new version
-				if err := backupGalleryDl(exeName); err != nil {
-					return fmt.Errorf("backup failed: %v", err)
-				}
-
-				if err := downloadLatestGalleryDl(client, exeName); err != nil {
-					// Download failed - try to restore backup
-					fmt.Printf("[!] Download failed: %v\n", err)
-					fmt.Printf("[*] Attempting to restore backup...\n")
-					if restoreErr := os.Rename(exeName+".old", exeName); restoreErr != nil {
-						return fmt.Errorf("download failed and could not restore backup: %v (restore error: %v)", err, restoreErr)
-					}
-					fmt.Printf("[*] Backup restored. Continuing with existing version.\n")
-					return nil
-				}
-			} else {
-				fmt.Printf("[*] Continuing with existing %s (version %s).\n", exeName, localVersion)
-			}
-		} else {
-			fmt.Printf("[*] Found %s (version %s) - up to date.\n", exeName, localVersion)
-		}
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("error checking for existing %s: %v", exeName, err)
-	}
-
-	// File doesn't exist - download it
-	fmt.Printf("[*] %s not found. Downloading the latest release from GitHub...\n", exeName)
-	return downloadLatestGalleryDl(client, exeName)
 }
 
 // parseFavoriteVideosFromFile reads the given JSON file and returns the list of video entries.
@@ -2795,14 +2629,28 @@ func main() {
 	}
 
 	// Attempt to get or download yt-dlp.exe (handles updates for existing files)
-	if err := getOrDownloadYtdlp(http.DefaultClient, "yt-dlp.exe"); err != nil {
+	if err := getOrDownloadTool(http.DefaultClient, &ToolConfig{
+		Name:            "yt-dlp",
+		ExeName:         "yt-dlp.exe",
+		GitHubRepo:      "yt-dlp/yt-dlp",
+		GetVersion:      getYtdlpVersion,
+		CompareVersions: compareVersions,
+		SelfUpdate:      updateYtdlp,
+	}); err != nil {
 		fmt.Printf("[!] Warning: %v\n", err)
 		// Not exiting here so you can still generate fav_videos.txt if needed
 	}
 
 	// Also get gallery-dl for photo support
 	galleryDlAvailable := false
-	if err := getOrDownloadGalleryDl(http.DefaultClient, "gallery-dl.exe"); err != nil {
+	if err := getOrDownloadTool(http.DefaultClient, &ToolConfig{
+		Name:            "gallery-dl",
+		ExeName:         "gallery-dl.exe",
+		GitHubRepo:      "mikf/gallery-dl",
+		GetVersion:      getGalleryDlVersion,
+		CompareVersions: compareGalleryDlVersions,
+		StripVPrefix:    true,
+	}); err != nil {
 		fmt.Printf("[!] Warning: gallery-dl not available, photo posts will be skipped: %v\n", err)
 	} else {
 		galleryDlAvailable = true

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -805,21 +805,53 @@ func isPhotoPost(originalURL string, client *http.Client) (bool, string, error) 
 
 // detectContentTypes detects whether each URL is a video or photo post.
 // This is done in batches to avoid overwhelming TikTok's servers.
-// Returns a map of URL -> ContentType ("video" or "photo")
-func detectContentTypes(entries []VideoEntry, client *http.Client) map[string]string {
+// Uses the provided cache to skip network requests for already-known URLs.
+// Returns a map of URL -> ContentType ("video" or "photo") including both cached and newly detected entries.
+func detectContentTypes(entries []VideoEntry, client *http.Client, cache map[string]string) map[string]string {
 	contentTypes := make(map[string]string)
 
-	fmt.Printf("[*] Detecting content types for %d URLs...\n", len(entries))
+	// Separate cached from uncached entries
+	var uncached []VideoEntry
+	cachedCount := 0
+	for _, entry := range entries {
+		if ct, ok := cache[entry.Link]; ok {
+			contentTypes[entry.Link] = ct
+			cachedCount++
+		} else {
+			uncached = append(uncached, entry)
+		}
+	}
 
-	// Process URLs to detect photos vs videos
+	if cachedCount > 0 && len(uncached) == 0 {
+		// Count cached types for display
+		photoCount := 0
+		videoCount := 0
+		for _, ct := range contentTypes {
+			if ct == "photo" {
+				photoCount++
+			} else {
+				videoCount++
+			}
+		}
+		fmt.Printf("[*] Content types: all %d URLs cached (%d videos, %d photos)\n", cachedCount, videoCount, photoCount)
+		return contentTypes
+	}
+
+	if cachedCount > 0 {
+		fmt.Printf("[*] Content types: %d cached, %d to detect...\n", cachedCount, len(uncached))
+	} else {
+		fmt.Printf("[*] Detecting content types for %d URLs...\n", len(entries))
+	}
+
+	// Process only uncached URLs to detect photos vs videos
 	photoCount := 0
 	videoCount := 0
 	errorCount := 0
 
-	for i, entry := range entries {
+	for i, entry := range uncached {
 		// Show progress every 50 URLs
-		if (i+1)%50 == 0 || i == len(entries)-1 {
-			fmt.Printf("[*] Checking URL %d/%d...\r", i+1, len(entries))
+		if (i+1)%50 == 0 || i == len(uncached)-1 {
+			fmt.Printf("[*] Checking URL %d/%d...\r", i+1, len(uncached))
 		}
 
 		isPhoto, _, err := isPhotoPost(entry.Link, client)
@@ -849,6 +881,53 @@ func detectContentTypes(entries []VideoEntry, client *http.Client) map[string]st
 	fmt.Println()
 
 	return contentTypes
+}
+
+// ContentTypeCache represents the persistent cache for content type detection results.
+// This avoids re-detecting video vs photo for URLs on subsequent runs.
+type ContentTypeCache struct {
+	Version int               `json:"version"`
+	Types   map[string]string `json:"types"` // URL -> "video" or "photo"
+}
+
+// loadContentTypeCache reads the content type cache from disk.
+// Returns an empty cache (not error) if the file doesn't exist or is corrupt.
+func loadContentTypeCache(cacheFilePath string) map[string]string {
+	data, err := os.ReadFile(cacheFilePath)
+	if err != nil {
+		return make(map[string]string)
+	}
+
+	var cache ContentTypeCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		fmt.Printf("[!] Warning: content type cache file is corrupt, starting fresh\n")
+		return make(map[string]string)
+	}
+
+	if cache.Types == nil {
+		return make(map[string]string)
+	}
+
+	return cache.Types
+}
+
+// saveContentTypeCache writes the content type cache to disk.
+func saveContentTypeCache(cacheFilePath string, types map[string]string) error {
+	cache := ContentTypeCache{
+		Version: 1,
+		Types:   types,
+	}
+
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal content type cache: %v", err)
+	}
+
+	if err := os.WriteFile(cacheFilePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write content type cache: %v", err)
+	}
+
+	return nil
 }
 
 // parseArchiveFile reads yt-dlp's download archive file and returns
@@ -2751,8 +2830,14 @@ func main() {
 
 	// Detect content types (video vs photo) if gallery-dl is available
 	hasPhotos := false
+	cacheFilePath := "content_types_cache.json"
 	if galleryDlAvailable {
-		contentTypes := detectContentTypes(videoEntries, http.DefaultClient)
+		cache := loadContentTypeCache(cacheFilePath)
+		contentTypes := detectContentTypes(videoEntries, http.DefaultClient, cache)
+		// Save updated cache to disk
+		if err := saveContentTypeCache(cacheFilePath, contentTypes); err != nil {
+			fmt.Printf("[!] Warning: could not save content type cache: %v\n", err)
+		}
 		// Apply content types to entries
 		for i := range videoEntries {
 			if ct, ok := contentTypes[videoEntries[i].Link]; ok {

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -16,7 +16,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -578,207 +577,6 @@ func extractVideoID(url string) string {
 	return ""
 }
 
-// isPhotoPost checks if a TikTok URL points to a photo/slideshow post by following
-// redirects and checking the final URL. Photo posts redirect to URLs containing "/photo/"
-// while video posts redirect to URLs containing "/video/".
-// Returns: (isPhoto bool, finalURL string, error)
-func isPhotoPost(originalURL string, client *http.Client) (bool, string, error) {
-	// First check if the URL already contains /photo/ (no redirect needed)
-	if strings.Contains(originalURL, "/photo/") {
-		return true, originalURL, nil
-	}
-
-	// Create a request to follow redirects and capture the final URL
-	req, err := http.NewRequest("HEAD", originalURL, nil)
-	if err != nil {
-		return false, "", fmt.Errorf("failed to create request: %v", err)
-	}
-
-	// Set a user agent to avoid blocks
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
-
-	// Create a per-request client to avoid mutating the shared client's CheckRedirect.
-	// This is safe for concurrent use since each goroutine gets its own client.
-	var finalURL string
-	perRequestClient := &http.Client{
-		Transport: client.Transport,
-		Timeout:   15 * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			finalURL = req.URL.String()
-			if len(via) >= 10 {
-				return fmt.Errorf("too many redirects")
-			}
-			return nil
-		},
-	}
-
-	resp, err := perRequestClient.Do(req)
-	if err != nil {
-		// If we got a final URL from redirects before the error, use it
-		if finalURL != "" && strings.Contains(finalURL, "/photo/") {
-			return true, finalURL, nil
-		}
-		return false, "", fmt.Errorf("failed to fetch URL: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// Use the final URL from redirects, or the response URL
-	if finalURL == "" {
-		finalURL = resp.Request.URL.String()
-	}
-
-	// Check if the final URL contains /photo/
-	isPhoto := strings.Contains(finalURL, "/photo/")
-	return isPhoto, finalURL, nil
-}
-
-// detectionResult holds the result of detecting whether a URL is a video or photo.
-type detectionResult struct {
-	url         string
-	contentType string
-	err         error
-}
-
-// detectContentTypes detects whether each URL is a video or photo post.
-// This is done in batches to avoid overwhelming TikTok's servers.
-// Uses the provided cache to skip network requests for already-known URLs.
-// Returns a map of URL -> ContentType ("video" or "photo") including both cached and newly detected entries.
-func detectContentTypes(entries []VideoEntry, client *http.Client, cache map[string]string, disableProgressBar bool) map[string]string {
-	contentTypes := make(map[string]string)
-
-	// Separate cached from uncached entries
-	var uncached []VideoEntry
-	cachedCount := 0
-	for _, entry := range entries {
-		if ct, ok := cache[entry.Link]; ok {
-			contentTypes[entry.Link] = ct
-			cachedCount++
-		} else {
-			uncached = append(uncached, entry)
-		}
-	}
-
-	if cachedCount > 0 && len(uncached) == 0 {
-		// Count cached types for display
-		photoCount := 0
-		videoCount := 0
-		for _, ct := range contentTypes {
-			if ct == "photo" {
-				photoCount++
-			} else {
-				videoCount++
-			}
-		}
-		fmt.Printf("[*] Content types: all %d URLs cached (%d videos, %d photos)\n", cachedCount, videoCount, photoCount)
-		return contentTypes
-	}
-
-	if cachedCount > 0 {
-		fmt.Printf("[*] Content types: %d cached, %d to detect...\n", cachedCount, len(uncached))
-	} else {
-		fmt.Printf("[*] Detecting content types for %d URLs...\n", len(entries))
-	}
-
-	if len(uncached) == 0 {
-		return contentTypes
-	}
-
-	// Set up progress bar if supported and not disabled
-	useProgressBar := !disableProgressBar && supportsANSI()
-	renderer := &ProgressRenderer{
-		enabled: useProgressBar,
-	}
-
-	// Process uncached URLs using a worker pool.
-	// 10 workers share a rate limiter ticker at 50ms. Each tick is consumed by exactly
-	// one worker (Go channel semantics), capping the aggregate rate at 20 req/s.
-	photoCount := 0
-	videoCount := 0
-	errorCount := 0
-	processed := 0
-
-	const numWorkers = 10
-	jobs := make(chan VideoEntry, numWorkers*2)
-	results := make(chan detectionResult, numWorkers*2)
-
-	rateLimiter := time.NewTicker(50 * time.Millisecond)
-	defer rateLimiter.Stop()
-
-	// Launch workers
-	var wg sync.WaitGroup
-	for w := 0; w < numWorkers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for entry := range jobs {
-				<-rateLimiter.C
-
-				isPhoto, _, err := isPhotoPost(entry.Link, client)
-				if err != nil {
-					results <- detectionResult{url: entry.Link, contentType: "video", err: err}
-					continue
-				}
-				ct := "video"
-				if isPhoto {
-					ct = "photo"
-				}
-				results <- detectionResult{url: entry.Link, contentType: ct}
-			}
-		}()
-	}
-
-	// Send jobs
-	go func() {
-		for _, entry := range uncached {
-			jobs <- entry
-		}
-		close(jobs)
-	}()
-
-	// Close results channel when all workers finish
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	// Collect results from a single goroutine (no mutex needed for contentTypes or progress)
-	for result := range results {
-		contentTypes[result.url] = result.contentType
-		if result.err != nil {
-			errorCount++
-		} else if result.contentType == "photo" {
-			photoCount++
-		} else {
-			videoCount++
-		}
-		processed++
-
-		if useProgressBar {
-			renderer.renderDetectionProgress(processed, len(uncached), videoCount, photoCount, errorCount)
-		} else {
-			if processed%50 == 0 || processed == len(uncached) {
-				fmt.Printf("[*] Checking URL %d/%d...\r", processed, len(uncached))
-			}
-		}
-	}
-
-	// Render final state and clear progress bar
-	if useProgressBar {
-		renderer.renderDetectionProgress(len(uncached), len(uncached), videoCount, photoCount, errorCount)
-		renderer.clearProgress()
-	} else {
-		fmt.Println()
-	}
-
-	fmt.Printf("[*] Content type detection complete: %d videos, %d photos", videoCount, photoCount)
-	if errorCount > 0 {
-		fmt.Printf(" (%d detection errors, defaulted to video)", errorCount)
-	}
-	fmt.Println()
-
-	return contentTypes
-}
-
 // ContentTypeCache represents the persistent cache for content type detection results.
 // This avoids re-detecting video vs photo for URLs on subsequent runs.
 type ContentTypeCache struct {
@@ -946,6 +744,113 @@ func shouldSkipCollection(entries []VideoEntry, archivePath string) (bool, strin
 	msg := fmt.Sprintf("%d new videos need download (out of %d total)",
 		len(missingIDs), len(entries))
 	return false, msg, nil
+}
+
+// identifyFailedEntries compares the download archive before and after a yt-dlp run
+// to determine which entries succeeded (newly downloaded), which were already downloaded,
+// and which failed (not in archive after run).
+func identifyFailedEntries(entries []VideoEntry, archiveBefore, archiveAfter map[string]bool) (succeeded, alreadyDownloaded, failed []VideoEntry) {
+	for _, entry := range entries {
+		videoID := extractVideoID(entry.Link)
+		if videoID == "" {
+			failed = append(failed, entry)
+			continue
+		}
+		if archiveBefore[videoID] {
+			alreadyDownloaded = append(alreadyDownloaded, entry)
+		} else if archiveAfter[videoID] {
+			succeeded = append(succeeded, entry)
+		} else {
+			failed = append(failed, entry)
+		}
+	}
+	return
+}
+
+// inferContentTypeFromFiles determines content type by checking what files exist on disk
+// for a given video ID. Returns "video" if .info.json exists, "photo" if other .json
+// metadata exists (excluding .info.json and index.json), or "" if nothing found.
+func inferContentTypeFromFiles(dir string, videoID string) string {
+	if videoID == "" {
+		return ""
+	}
+
+	// Check for yt-dlp .info.json files (indicates video)
+	infoPattern := filepath.Join(dir, fmt.Sprintf("*%s*.info.json", videoID))
+	infoMatches, _ := filepath.Glob(infoPattern)
+	if len(infoMatches) > 0 {
+		return "video"
+	}
+
+	// Check for video files directly (mp4, webm, etc.)
+	for _, ext := range []string{"mp4", "mkv", "webm", "mov"} {
+		videoPattern := filepath.Join(dir, fmt.Sprintf("*%s*.%s", videoID, ext))
+		videoMatches, _ := filepath.Glob(videoPattern)
+		if len(videoMatches) > 0 {
+			return "video"
+		}
+	}
+
+	// Check for photo files (jpg, png, webp with this video ID but no .info.json)
+	for _, ext := range []string{"jpg", "jpeg", "png", "webp"} {
+		photoPattern := filepath.Join(dir, fmt.Sprintf("*%s*.%s", videoID, ext))
+		photoMatches, _ := filepath.Glob(photoPattern)
+		if len(photoMatches) > 0 {
+			return "photo"
+		}
+	}
+
+	// Check for gallery-dl metadata .json files (not .info.json, not index.json)
+	jsonPattern := filepath.Join(dir, fmt.Sprintf("*%s*.json", videoID))
+	jsonMatches, _ := filepath.Glob(jsonPattern)
+	for _, match := range jsonMatches {
+		base := filepath.Base(match)
+		if !strings.HasSuffix(base, ".info.json") && base != "index.json" {
+			return "photo"
+		}
+	}
+
+	return ""
+}
+
+// applyContentTypesFromCache applies cached content types and infers types from files on disk
+// for entries that don't have a cached type. Returns the number of entries that remain unknown.
+func applyContentTypesFromCache(entries []VideoEntry, cache map[string]string, dir string, organizeByCollection bool) int {
+	unknown := 0
+	for i := range entries {
+		// Already has a type assigned
+		if entries[i].ContentType != "" {
+			continue
+		}
+
+		// Try cache
+		if ct, ok := cache[entries[i].Link]; ok {
+			entries[i].ContentType = ct
+			continue
+		}
+
+		// Try inferring from files on disk
+		videoID := extractVideoID(entries[i].Link)
+		if videoID == "" {
+			unknown++
+			continue
+		}
+
+		lookupDir := dir
+		if organizeByCollection {
+			lookupDir = sanitizeCollectionName(entries[i].Collection)
+		}
+
+		ct := inferContentTypeFromFiles(lookupDir, videoID)
+		if ct != "" {
+			entries[i].ContentType = ct
+			// Update cache for future runs
+			cache[entries[i].Link] = ct
+		} else {
+			unknown++
+		}
+	}
+	return unknown
 }
 
 // parseInfoJSON reads a yt-dlp .info.json file and extracts metadata
@@ -1480,31 +1385,6 @@ func (pr *ProgressRenderer) renderProgress(state *ProgressState) {
 	pr.writeLine(line)
 }
 
-// renderDetectionProgress renders a progress bar for content type detection.
-// Format: "Detecting content types (X/Y) | ████░░░ Z% | Videos: N | Photos: N | Errors: N"
-func (pr *ProgressRenderer) renderDetectionProgress(current, total, videoCount, photoCount, errorCount int) {
-	if !pr.enabled {
-		return
-	}
-
-	bar, percentage := buildProgressBar(current, total, 20)
-
-	green := "\033[32m"
-	cyan := "\033[36m"
-	red := "\033[31m"
-	reset := "\033[0m"
-
-	line := fmt.Sprintf("\rDetecting content types (%d/%d) | %s %.1f%% | %sVideos: %d%s | %sPhotos: %d%s | %sErrors: %d%s",
-		current, total,
-		bar, percentage,
-		green, videoCount, reset,
-		cyan, photoCount, reset,
-		red, errorCount, reset,
-	)
-
-	pr.writeLine(line)
-}
-
 // clearProgress clears the progress bar line
 func (pr *ProgressRenderer) clearProgress() {
 	if !pr.enabled || pr.lastLineLen == 0 {
@@ -1964,6 +1844,33 @@ func parseGalleryDlOutput(lines []string, entries []VideoEntry) (success int, fa
 	return success, failures
 }
 
+// getPhotoArchivePath returns the path to the photo archive file for a given output directory.
+func getPhotoArchivePath(outputDir string, organizeByCollection bool) string {
+	if organizeByCollection {
+		return filepath.Join(outputDir, "photo_archive.txt")
+	}
+	return "photo_archive.txt"
+}
+
+// appendToPhotoArchive appends successfully downloaded photo IDs to the photo archive file.
+func appendToPhotoArchive(archivePath string, entries []VideoEntry) error {
+	f, err := os.OpenFile(archivePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open photo archive for writing: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	for _, entry := range entries {
+		videoID := extractVideoID(entry.Link)
+		if videoID != "" {
+			if _, err := fmt.Fprintf(f, "tiktok %s\n", videoID); err != nil {
+				return fmt.Errorf("failed to write to photo archive: %v", err)
+			}
+		}
+	}
+	return nil
+}
+
 // runGalleryDl runs gallery-dl to download photo/slideshow posts
 func runGalleryDl(psPrefix, outputDir string, config *Config, entries []VideoEntry) (*CollectionResult, error) {
 	if len(entries) == 0 {
@@ -1982,12 +1889,52 @@ func runGalleryDl(psPrefix, outputDir string, config *Config, entries []VideoEnt
 		collectionName = "photos"
 	}
 
-	fmt.Printf("[*] Running gallery-dl for %d photo posts in %s...\n", len(entries), collectionName)
+	// Photo archive skip optimization (same concept as yt-dlp's download archive)
+	archivePath := getPhotoArchivePath(outputDir, config.OrganizeByCollection)
+	photosToDownload := entries
+	skippedCount := 0
+
+	if !config.DisableResume {
+		archive, err := parseArchiveFile(archivePath)
+		if err == nil && len(archive) > 0 {
+			var filtered []VideoEntry
+			for _, entry := range entries {
+				videoID := extractVideoID(entry.Link)
+				if videoID != "" && archive[videoID] {
+					skippedCount++
+				} else {
+					filtered = append(filtered, entry)
+				}
+			}
+			photosToDownload = filtered
+		}
+	}
+
+	// If all photos are skipped, return early
+	if len(photosToDownload) == 0 {
+		fmt.Printf("[*] %s collection: All %d photos already downloaded (skipping gallery-dl)\n",
+			collectionName, len(entries))
+		return &CollectionResult{
+			Name:           collectionName,
+			Attempted:      len(entries),
+			Success:        len(entries),
+			Failed:         0,
+			Skipped:        len(entries),
+			FailureDetails: []FailureDetail{},
+		}, nil
+	}
+
+	if skippedCount > 0 {
+		fmt.Printf("[*] %s collection: %d photos to download (%d skipped)\n",
+			collectionName, len(photosToDownload), skippedCount)
+	}
+
+	fmt.Printf("[*] Running gallery-dl for %d photo posts in %s...\n", len(photosToDownload), collectionName)
 	cmdStr := fmt.Sprintf("%sgallery-dl.exe", psPrefix)
 
 	// Write URLs to temp file
 	tempFile := filepath.Join(outputDir, "photo_urls_temp.txt")
-	if err := writeVideoEntriesToFile(entries, tempFile); err != nil {
+	if err := writeVideoEntriesToFile(photosToDownload, tempFile); err != nil {
 		return nil, fmt.Errorf("failed to create temp URL file: %v", err)
 	}
 	defer func() { _ = os.Remove(tempFile) }()
@@ -2022,14 +1969,36 @@ func runGalleryDl(psPrefix, outputDir string, config *Config, entries []VideoEnt
 
 	// Parse output
 	combined := combineOutputLines(stdoutBuf.String(), stderrBuf.String())
-	successCount, failures := parseGalleryDlOutput(combined, entries)
+	successCount, failures := parseGalleryDlOutput(combined, photosToDownload)
+
+	// Append succeeded entries to photo archive (for future skip optimization)
+	if !config.DisableResume && successCount > 0 {
+		// Identify succeeded entries by checking which video IDs now have files on disk
+		var succeededEntries []VideoEntry
+		for _, entry := range photosToDownload {
+			videoID := extractVideoID(entry.Link)
+			if videoID == "" {
+				continue
+			}
+			// Check if files were downloaded for this ID
+			ct := inferContentTypeFromFiles(outputDir, videoID)
+			if ct == "photo" {
+				succeededEntries = append(succeededEntries, entry)
+			}
+		}
+		if len(succeededEntries) > 0 {
+			if archiveErr := appendToPhotoArchive(archivePath, succeededEntries); archiveErr != nil {
+				fmt.Printf("[!] Warning: Failed to update photo archive: %v\n", archiveErr)
+			}
+		}
+	}
 
 	result := &CollectionResult{
 		Name:           collectionName,
 		Attempted:      len(entries),
 		Failed:         len(failures),
-		Success:        successCount,
-		Skipped:        len(entries) - successCount - len(failures),
+		Success:        successCount + skippedCount,
+		Skipped:        skippedCount,
 		FailureDetails: failures,
 	}
 
@@ -2043,9 +2012,9 @@ func runGalleryDl(psPrefix, outputDir string, config *Config, entries []VideoEnt
 
 	if err != nil || len(failures) > 0 {
 		fmt.Printf("[!] Photo download completed with %d failures out of %d photos.\n",
-			result.Failed, len(entries))
+			result.Failed, len(photosToDownload))
 	} else {
-		fmt.Printf("[*] Successfully downloaded all %d photos.\n", result.Success)
+		fmt.Printf("[*] Successfully downloaded all %d photos.\n", successCount)
 	}
 
 	return result, err
@@ -2640,6 +2609,13 @@ func main() {
 
 		fmt.Printf("[*] Loaded %d video entries from '%s'\n", len(videoEntries), config.JSONFile)
 
+		// Apply content types from cache and file inference for proper index generation
+		indexCache := loadContentTypeCache("content_types_cache.json")
+		unknownCount := applyContentTypesFromCache(videoEntries, indexCache, ".", config.OrganizeByCollection)
+		if unknownCount > 0 {
+			fmt.Printf("[*] %d entries have unknown content type (no cache or files found)\n", unknownCount)
+		}
+
 		if config.OrganizeByCollection {
 			// Regenerate indexes for each collection
 			collections := make(map[string]bool)
@@ -2667,6 +2643,11 @@ func main() {
 			} else {
 				fmt.Println("[*] Generated index.html and index.json")
 			}
+		}
+
+		// Save any updated cache entries from file inference
+		if err := saveContentTypeCache("content_types_cache.json", indexCache); err != nil {
+			fmt.Printf("[!] Warning: could not save content type cache: %v\n", err)
 		}
 		return
 	}
@@ -2734,37 +2715,36 @@ func main() {
 
 	fmt.Printf("[*] Successfully loaded %d video entries from '%s'\n", len(videoEntries), config.JSONFile)
 
-	// Detect content types (video vs photo) if gallery-dl is available
-	hasPhotos := false
+	// Apply known content types from cache and file inference (no network requests)
 	cacheFilePath := "content_types_cache.json"
-	if galleryDlAvailable {
-		cache := loadContentTypeCache(cacheFilePath)
-		contentTypes := detectContentTypes(videoEntries, http.DefaultClient, cache, config.DisableProgressBar)
-		// Save updated cache to disk
-		if err := saveContentTypeCache(cacheFilePath, contentTypes); err != nil {
-			fmt.Printf("[!] Warning: could not save content type cache: %v\n", err)
-		}
-		// Apply content types to entries
-		for i := range videoEntries {
-			if ct, ok := contentTypes[videoEntries[i].Link]; ok {
-				videoEntries[i].ContentType = ct
-				if ct == "photo" {
-					hasPhotos = true
-				}
-			}
+	cache := loadContentTypeCache(cacheFilePath)
+	unknownCount := applyContentTypesFromCache(videoEntries, cache, ".", config.OrganizeByCollection)
+
+	// Count known videos and photos
+	knownVideos, knownPhotos := separateEntriesByContentType(videoEntries)
+	cachedVideoCount := 0
+	cachedPhotoCount := 0
+	for _, e := range knownVideos {
+		if e.ContentType == "video" {
+			cachedVideoCount++
 		}
 	}
+	cachedPhotoCount = len(knownPhotos)
 
-	// Write video entries to files
+	if cachedVideoCount+cachedPhotoCount > 0 {
+		fmt.Printf("[*] Content types: %d videos, %d photos from cache/files", cachedVideoCount, cachedPhotoCount)
+		if unknownCount > 0 {
+			fmt.Printf(", %d unknown (will try yt-dlp first)", unknownCount)
+		}
+		fmt.Println()
+	} else if unknownCount > 0 {
+		fmt.Printf("[*] No cached content types found. All %d URLs will be sent to yt-dlp first.\n", unknownCount)
+	}
+
+	// Write ALL video entries to files (unknowns go in the video file for yt-dlp)
 	if err := writeFavoriteVideosToFile(videoEntries, config.OutputName, config.OrganizeByCollection); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-	}
-
-	// Count videos and photos for display
-	videos, photos := separateEntriesByContentType(videoEntries)
-	if hasPhotos {
-		fmt.Printf("[*] Found %d videos and %d photos\n", len(videos), len(photos))
 	}
 
 	// Construct the recommended yt-dlp command
@@ -2807,7 +2787,7 @@ func main() {
 		}
 
 		if config.OrganizeByCollection {
-			// Run yt-dlp and gallery-dl for each collection
+			// Run yt-dlp first, then gallery-dl fallback for each collection
 			collections := make(map[string]bool)
 			for _, entry := range videoEntries {
 				collections[sanitizeCollectionName(entry.Collection)] = true
@@ -2815,18 +2795,40 @@ func main() {
 			for collection := range collections {
 				collectionEntries := getEntriesForCollection(videoEntries, collection)
 
-				// Separate videos and photos for this collection
-				collectionVideos, collectionPhotos := separateEntriesByContentType(collectionEntries)
+				// Separate known-video, known-photo, and unknown entries
+				var knownVideoEntries, knownPhotoEntries, unknownEntries []VideoEntry
+				for _, entry := range collectionEntries {
+					switch entry.ContentType {
+					case "video":
+						knownVideoEntries = append(knownVideoEntries, entry)
+					case "photo":
+						knownPhotoEntries = append(knownPhotoEntries, entry)
+					default:
+						unknownEntries = append(unknownEntries, entry)
+					}
+				}
 
 				var allFailures []FailureDetail
 
-				// Process videos with yt-dlp
-				if len(collectionVideos) > 0 {
+				// Phase 1: yt-dlp pass (known videos + unknown entries)
+				ytdlpEntries := append(knownVideoEntries, unknownEntries...)
+				if len(ytdlpEntries) > 0 {
 					collectionFilename := getVideoOutputFilename(collection)
 					collectionOutputName := filepath.Join(collection, collectionFilename)
 
-					fmt.Printf("[*] Processing collection: %s (%d videos)\n", collection, len(collectionVideos))
-					result, _ := runYtdlp(psPrefix, collectionOutputName, config, collectionVideos)
+					// Write the combined list for yt-dlp
+					if err := writeVideoEntriesToFile(ytdlpEntries, collectionOutputName); err != nil {
+						fmt.Printf("[!] Error writing URL file: %v\n", err)
+						continue
+					}
+
+					// Snapshot archive before yt-dlp
+					archivePath := filepath.Join(collection, "download_archive.txt")
+					archiveBefore, _ := parseArchiveFile(archivePath)
+
+					fmt.Printf("[*] Processing collection: %s (%d videos + %d unknown)\n",
+						collection, len(knownVideoEntries), len(unknownEntries))
+					result, _ := runYtdlp(psPrefix, collectionOutputName, config, ytdlpEntries)
 
 					// Track session results
 					if result != nil {
@@ -2834,12 +2836,36 @@ func main() {
 						session.Collections = append(session.Collections, *result)
 						allFailures = append(allFailures, result.FailureDetails...)
 					}
+
+					// Phase 1b: Diff archive to identify failed unknowns
+					if len(unknownEntries) > 0 {
+						archiveAfter, _ := parseArchiveFile(archivePath)
+						succeeded, _, failed := identifyFailedEntries(unknownEntries, archiveBefore, archiveAfter)
+
+						// Update cache: succeeded unknowns are videos
+						for _, entry := range succeeded {
+							cache[entry.Link] = "video"
+						}
+
+						// Failed unknowns become candidates for gallery-dl
+						if len(failed) > 0 && galleryDlAvailable {
+							knownPhotoEntries = append(knownPhotoEntries, failed...)
+						} else {
+							// No gallery-dl: update cache for failed unknowns that have files on disk
+							for _, entry := range failed {
+								videoID := extractVideoID(entry.Link)
+								if ct := inferContentTypeFromFiles(collection, videoID); ct != "" {
+									cache[entry.Link] = ct
+								}
+							}
+						}
+					}
 				}
 
-				// Process photos with gallery-dl
-				if len(collectionPhotos) > 0 && galleryDlAvailable {
-					fmt.Printf("[*] Processing collection: %s (%d photos)\n", collection, len(collectionPhotos))
-					result, _ := runGalleryDl(psPrefix, collection, config, collectionPhotos)
+				// Phase 2: gallery-dl pass (known photos + failed unknowns from yt-dlp)
+				if len(knownPhotoEntries) > 0 && galleryDlAvailable {
+					fmt.Printf("[*] Processing collection: %s (%d photos)\n", collection, len(knownPhotoEntries))
+					result, _ := runGalleryDl(psPrefix, collection, config, knownPhotoEntries)
 
 					// Track session results
 					if result != nil {
@@ -2847,9 +2873,28 @@ func main() {
 						session.Collections = append(session.Collections, *result)
 						allFailures = append(allFailures, result.FailureDetails...)
 					}
+
+					// Update cache: entries that gallery-dl succeeded on are photos
+					for _, entry := range knownPhotoEntries {
+						videoID := extractVideoID(entry.Link)
+						if ct := inferContentTypeFromFiles(collection, videoID); ct == "photo" {
+							cache[entry.Link] = "photo"
+						}
+					}
 				}
 
-				// Generate index after download completes (pass all failures for error details)
+				// Phase 3: Save cache, generate index
+				if err := saveContentTypeCache(cacheFilePath, cache); err != nil {
+					fmt.Printf("[!] Warning: could not save content type cache: %v\n", err)
+				}
+
+				// Re-apply content types to entries for index generation
+				for i := range collectionEntries {
+					if ct, ok := cache[collectionEntries[i].Link]; ok {
+						collectionEntries[i].ContentType = ct
+					}
+				}
+
 				if err := generateCollectionIndex(collection, collectionEntries, allFailures); err != nil {
 					fmt.Printf("[!] Warning: Failed to generate index for %s: %v\n", collection, err)
 				} else {
@@ -2857,37 +2902,96 @@ func main() {
 				}
 			}
 		} else {
-			// Flat structure - separate videos and photos
-			flatVideos, flatPhotos := separateEntriesByContentType(videoEntries)
-			var allFailures []FailureDetail
-
-			// Process videos with yt-dlp
-			if len(flatVideos) > 0 {
-				result, _ := runYtdlp(psPrefix, config.OutputName, config, flatVideos)
-
-				// Track session results
-				if result != nil {
-					result.ContentType = "video"
-					session.Collections = append(session.Collections, *result)
-					allFailures = append(allFailures, result.FailureDetails...)
+			// Flat structure - same try-then-fallback approach
+			var knownVideoEntries, knownPhotoEntries, unknownEntries []VideoEntry
+			for _, entry := range videoEntries {
+				switch entry.ContentType {
+				case "video":
+					knownVideoEntries = append(knownVideoEntries, entry)
+				case "photo":
+					knownPhotoEntries = append(knownPhotoEntries, entry)
+				default:
+					unknownEntries = append(unknownEntries, entry)
 				}
 			}
 
-			// Process photos with gallery-dl
-			if len(flatPhotos) > 0 && galleryDlAvailable {
-				fmt.Printf("[*] Processing %d photos with gallery-dl...\n", len(flatPhotos))
-				dir, _ := filepath.Abs(".")
-				result, _ := runGalleryDl(psPrefix, dir, config, flatPhotos)
+			var allFailures []FailureDetail
 
-				// Track session results
+			// Phase 1: yt-dlp pass (known videos + unknown entries)
+			ytdlpEntries := append(knownVideoEntries, unknownEntries...)
+			if len(ytdlpEntries) > 0 {
+				// Write the combined list for yt-dlp
+				if err := writeVideoEntriesToFile(ytdlpEntries, config.OutputName); err != nil {
+					fmt.Printf("[!] Error writing URL file: %v\n", err)
+				} else {
+					// Snapshot archive before yt-dlp
+					archiveBefore, _ := parseArchiveFile("download_archive.txt")
+
+					result, _ := runYtdlp(psPrefix, config.OutputName, config, ytdlpEntries)
+
+					if result != nil {
+						result.ContentType = "video"
+						session.Collections = append(session.Collections, *result)
+						allFailures = append(allFailures, result.FailureDetails...)
+					}
+
+					// Phase 1b: Diff archive to identify failed unknowns
+					if len(unknownEntries) > 0 {
+						archiveAfter, _ := parseArchiveFile("download_archive.txt")
+						succeeded, _, failed := identifyFailedEntries(unknownEntries, archiveBefore, archiveAfter)
+
+						for _, entry := range succeeded {
+							cache[entry.Link] = "video"
+						}
+
+						if len(failed) > 0 && galleryDlAvailable {
+							knownPhotoEntries = append(knownPhotoEntries, failed...)
+						} else {
+							dir, _ := filepath.Abs(".")
+							for _, entry := range failed {
+								videoID := extractVideoID(entry.Link)
+								if ct := inferContentTypeFromFiles(dir, videoID); ct != "" {
+									cache[entry.Link] = ct
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// Phase 2: gallery-dl pass
+			if len(knownPhotoEntries) > 0 && galleryDlAvailable {
+				fmt.Printf("[*] Processing %d photos with gallery-dl...\n", len(knownPhotoEntries))
+				dir, _ := filepath.Abs(".")
+				result, _ := runGalleryDl(psPrefix, dir, config, knownPhotoEntries)
+
 				if result != nil {
 					result.ContentType = "photo"
 					session.Collections = append(session.Collections, *result)
 					allFailures = append(allFailures, result.FailureDetails...)
 				}
+
+				for _, entry := range knownPhotoEntries {
+					videoID := extractVideoID(entry.Link)
+					absDir, _ := filepath.Abs(".")
+					if ct := inferContentTypeFromFiles(absDir, videoID); ct == "photo" {
+						cache[entry.Link] = "photo"
+					}
+				}
 			}
 
-			// Generate index for flat structure in current directory
+			// Phase 3: Save cache, generate index
+			if err := saveContentTypeCache(cacheFilePath, cache); err != nil {
+				fmt.Printf("[!] Warning: could not save content type cache: %v\n", err)
+			}
+
+			// Re-apply content types to entries for index generation
+			for i := range videoEntries {
+				if ct, ok := cache[videoEntries[i].Link]; ok {
+					videoEntries[i].ContentType = ct
+				}
+			}
+
 			dir, err := filepath.Abs(".")
 			if err != nil {
 				dir = "."

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -442,6 +442,7 @@ func updateYtdlp(exePath string) error {
 	}
 	return nil
 }
+
 // promptForUpdate asks the user if they want to update yt-dlp.exe
 // Returns true if user wants to update (default is yes)
 func promptForUpdate() bool {
@@ -1072,6 +1073,7 @@ func processOutput(stdout, stderr io.Reader, stdoutWriter, stderrWriter io.Write
 	// Process stdout
 	go func() {
 		scanner := bufio.NewScanner(stdout)
+		scanner.Split(scanLinesAndCR)
 		for scanner.Scan() {
 			line := scanner.Text()
 
@@ -1122,12 +1124,16 @@ func processOutput(stdout, stderr io.Reader, stdoutWriter, stderrWriter io.Write
 				renderer.renderProgress(state)
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			_, _ = fmt.Fprintf(stderrWriter, "[!] stdout scanner error: %v\n", err)
+		}
 		done <- true
 	}()
 
 	// Process stderr
 	go func() {
 		scanner := bufio.NewScanner(stderr)
+		scanner.Split(scanLinesAndCR)
 		for scanner.Scan() {
 			line := scanner.Text()
 
@@ -1148,6 +1154,9 @@ func processOutput(stdout, stderr io.Reader, stdoutWriter, stderrWriter io.Write
 			if renderer != nil && renderer.enabled {
 				renderer.renderProgress(state)
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			_, _ = fmt.Fprintf(stderrWriter, "[!] stderr scanner error: %v\n", err)
 		}
 		done <- true
 	}()
@@ -1277,6 +1286,7 @@ func isVerboseLine(line string) bool {
 		"Video thumbnail is already present",
 		"Video metadata is already present",
 		"[download] 100%",
+		"% of ",
 	}
 
 	for _, pattern := range verbosePatterns {
@@ -1292,6 +1302,41 @@ func isVerboseLine(line string) bool {
 // Returns: true if this is an error message
 func isErrorLine(line string) bool {
 	return strings.Contains(line, "ERROR: [TikTok]")
+}
+
+// scanLinesAndCR is a bufio.SplitFunc that splits on \n, \r\n, or bare \r.
+// yt-dlp uses bare \r for in-place percentage updates (e.g., "[download]  50.2% of ~10MiB").
+// The default bufio.ScanLines only splits on \n, so bare \r lines accumulate into a single
+// token that can exceed the 64KB scanner buffer, silently killing the scanner.
+func scanLinesAndCR(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	// Find the earliest \r or \n
+	for i := 0; i < len(data); i++ {
+		if data[i] == '\n' {
+			return i + 1, data[:i], nil
+		}
+		if data[i] == '\r' {
+			// Check for \r\n
+			if i+1 < len(data) {
+				if data[i+1] == '\n' {
+					return i + 2, data[:i], nil
+				}
+				return i + 1, data[:i], nil
+			}
+			// \r at end of buffer - if at EOF, return it; otherwise request more data
+			if atEOF {
+				return len(data), data[:i], nil
+			}
+			return 0, nil, nil // need more data to check for \r\n
+		}
+	}
+	// No delimiter found
+	if atEOF {
+		return len(data), data, nil
+	}
+	return 0, nil, nil // request more data
 }
 
 // supportsANSI checks if the terminal supports ANSI escape codes
@@ -1718,6 +1763,8 @@ func runYtdlpWithRunner(runner CommandRunner, psPrefix, outputName string, confi
 		"-a", targetFile,
 		"--output", outputFormat,
 		"--write-info-json", // Save metadata JSON for each video
+		"--add-headers",
+		"User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", // set user-agent for chrome not yt-dlp's default
 	}
 
 	// Add thumbnail download unless skipped
@@ -1820,6 +1867,7 @@ func parseGalleryDlOutput(lines []string, entries []VideoEntry) (success int, fa
 			if matches := galleryVideoIDPattern.FindStringSubmatch(line); len(matches) > 1 {
 				videoID := matches[1]
 				if !seenIDs[videoID] {
+					seenIDs[videoID] = true
 					failures = append(failures, FailureDetail{
 						VideoID:      videoID,
 						VideoURL:     idToURL[videoID],
@@ -1969,10 +2017,10 @@ func runGalleryDl(psPrefix, outputDir string, config *Config, entries []VideoEnt
 
 	// Parse output
 	combined := combineOutputLines(stdoutBuf.String(), stderrBuf.String())
-	successCount, failures := parseGalleryDlOutput(combined, photosToDownload)
+	_, failures := parseGalleryDlOutput(combined, photosToDownload)
 
 	// Append succeeded entries to photo archive (for future skip optimization)
-	if !config.DisableResume && successCount > 0 {
+	if !config.DisableResume && len(photosToDownload) > len(failures) {
 		// Identify succeeded entries by checking which video IDs now have files on disk
 		var succeededEntries []VideoEntry
 		for _, entry := range photosToDownload {
@@ -1997,7 +2045,7 @@ func runGalleryDl(psPrefix, outputDir string, config *Config, entries []VideoEnt
 		Name:           collectionName,
 		Attempted:      len(entries),
 		Failed:         len(failures),
-		Success:        successCount + skippedCount,
+		Success:        len(entries) - len(failures),
 		Skipped:        skippedCount,
 		FailureDetails: failures,
 	}
@@ -2014,7 +2062,7 @@ func runGalleryDl(psPrefix, outputDir string, config *Config, entries []VideoEnt
 		fmt.Printf("[!] Photo download completed with %d failures out of %d photos.\n",
 			result.Failed, len(photosToDownload))
 	} else {
-		fmt.Printf("[*] Successfully downloaded all %d photos.\n", successCount)
+		fmt.Printf("[*] Successfully downloaded all %d photos.\n", result.Success-result.Skipped)
 	}
 
 	return result, err

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -1539,6 +1539,37 @@ func supportsANSI() bool {
 	return false
 }
 
+// getWriter returns the output writer, defaulting to os.Stdout
+func (pr *ProgressRenderer) getWriter() io.Writer {
+	if pr.writer != nil {
+		return pr.writer
+	}
+	return os.Stdout
+}
+
+// buildProgressBar creates a progress bar string and percentage from current/total values
+func buildProgressBar(current, total, barWidth int) (string, float64) {
+	percentage := 0.0
+	if total > 0 {
+		percentage = float64(current) / float64(total) * 100
+	}
+	filledWidth := int(float64(barWidth) * percentage / 100)
+	if filledWidth > barWidth {
+		filledWidth = barWidth
+	}
+	bar := strings.Repeat("█", filledWidth) + strings.Repeat("░", barWidth-filledWidth)
+	return bar, percentage
+}
+
+// writeLine writes a carriage-return-prefixed line and pads to clear any previous longer line
+func (pr *ProgressRenderer) writeLine(line string) {
+	if len(line) < pr.lastLineLen {
+		line += strings.Repeat(" ", pr.lastLineLen-len(line))
+	}
+	pr.lastLineLen = len(line)
+	_, _ = fmt.Fprint(pr.getWriter(), line)
+}
+
 // renderProgress displays a live progress bar using ANSI escape codes
 // Format: "Downloading favorites (87/92) | ████████████░░░ 94.6% | Success: 85 | Failed: 2"
 func (pr *ProgressRenderer) renderProgress(state *ProgressState) {
@@ -1546,59 +1577,23 @@ func (pr *ProgressRenderer) renderProgress(state *ProgressState) {
 		return
 	}
 
-	// Default to stdout if no writer specified
-	out := pr.writer
-	if out == nil {
-		out = os.Stdout
-	}
+	bar, percentage := buildProgressBar(state.CurrentIndex, state.TotalVideos, 20)
 
-	// Calculate percentage
-	percentage := 0.0
-	if state.TotalVideos > 0 {
-		percentage = float64(state.CurrentIndex) / float64(state.TotalVideos) * 100
-	}
-
-	// Create progress bar (20 characters wide)
-	barWidth := 20
-	filledWidth := int(float64(barWidth) * percentage / 100)
-	if filledWidth > barWidth {
-		filledWidth = barWidth
-	}
-
-	bar := strings.Repeat("█", filledWidth) + strings.Repeat("░", barWidth-filledWidth)
-
-	// Color codes
 	green := "\033[32m"
 	yellow := "\033[33m"
 	red := "\033[31m"
 	reset := "\033[0m"
 
-	// Build progress line
 	line := fmt.Sprintf("\rDownloading %s (%d/%d) | %s %.1f%% | %sSuccess: %d%s | %sSkipped: %d%s | %sFailed: %d%s",
 		state.CollectionName,
-		state.CurrentIndex,
-		state.TotalVideos,
-		bar,
-		percentage,
-		green,
-		state.SuccessCount,
-		reset,
-		yellow,
-		state.SkippedCount,
-		reset,
-		red,
-		state.FailureCount,
-		reset,
+		state.CurrentIndex, state.TotalVideos,
+		bar, percentage,
+		green, state.SuccessCount, reset,
+		yellow, state.SkippedCount, reset,
+		red, state.FailureCount, reset,
 	)
 
-	// Clear previous line if it was longer
-	if len(line) < pr.lastLineLen {
-		line += strings.Repeat(" ", pr.lastLineLen-len(line))
-	}
-	pr.lastLineLen = len(line)
-
-	// Print progress (using \r to overwrite current line)
-	_, _ = fmt.Fprint(out, line)
+	pr.writeLine(line)
 }
 
 // renderDetectionProgress renders a progress bar for content type detection.
@@ -1608,58 +1603,22 @@ func (pr *ProgressRenderer) renderDetectionProgress(current, total, videoCount, 
 		return
 	}
 
-	// Default to stdout if no writer specified
-	out := pr.writer
-	if out == nil {
-		out = os.Stdout
-	}
+	bar, percentage := buildProgressBar(current, total, 20)
 
-	// Calculate percentage
-	percentage := 0.0
-	if total > 0 {
-		percentage = float64(current) / float64(total) * 100
-	}
-
-	// Create progress bar (20 characters wide)
-	barWidth := 20
-	filledWidth := int(float64(barWidth) * percentage / 100)
-	if filledWidth > barWidth {
-		filledWidth = barWidth
-	}
-
-	bar := strings.Repeat("█", filledWidth) + strings.Repeat("░", barWidth-filledWidth)
-
-	// Color codes
 	green := "\033[32m"
 	cyan := "\033[36m"
 	red := "\033[31m"
 	reset := "\033[0m"
 
-	// Build progress line
 	line := fmt.Sprintf("\rDetecting content types (%d/%d) | %s %.1f%% | %sVideos: %d%s | %sPhotos: %d%s | %sErrors: %d%s",
-		current,
-		total,
-		bar,
-		percentage,
-		green,
-		videoCount,
-		reset,
-		cyan,
-		photoCount,
-		reset,
-		red,
-		errorCount,
-		reset,
+		current, total,
+		bar, percentage,
+		green, videoCount, reset,
+		cyan, photoCount, reset,
+		red, errorCount, reset,
 	)
 
-	// Clear previous line if it was longer
-	if len(line) < pr.lastLineLen {
-		line += strings.Repeat(" ", pr.lastLineLen-len(line))
-	}
-	pr.lastLineLen = len(line)
-
-	// Print progress (using \r to overwrite current line)
-	_, _ = fmt.Fprint(out, line)
+	pr.writeLine(line)
 }
 
 // clearProgress clears the progress bar line
@@ -1667,15 +1626,7 @@ func (pr *ProgressRenderer) clearProgress() {
 	if !pr.enabled || pr.lastLineLen == 0 {
 		return
 	}
-
-	// Default to stdout if no writer specified
-	out := pr.writer
-	if out == nil {
-		out = os.Stdout
-	}
-
-	// Clear line and move to start
-	_, _ = fmt.Fprint(out, "\r"+strings.Repeat(" ", pr.lastLineLen)+"\r")
+	_, _ = fmt.Fprint(pr.getWriter(), "\r"+strings.Repeat(" ", pr.lastLineLen)+"\r")
 	pr.lastLineLen = 0
 }
 

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -30,8 +31,8 @@ var (
 	}
 
 	// Pre-compiled regex patterns for parsing yt-dlp and gallery-dl output
-	ytdlpErrorPattern    = regexp.MustCompile(`ERROR:\s*\[TikTok\]\s*(\d+):\s*(.+)`)
-	progressLinePattern  = regexp.MustCompile(`\[download\] Downloading item (\d+) of (\d+)`)
+	ytdlpErrorPattern     = regexp.MustCompile(`ERROR:\s*\[TikTok\]\s*(\d+):\s*(.+)`)
+	progressLinePattern   = regexp.MustCompile(`\[download\] Downloading item (\d+) of (\d+)`)
 	gallerySuccessPattern = regexp.MustCompile(`^#\d+`)
 	galleryErrorPattern   = regexp.MustCompile(`(?i)error|failed|\[error\]`)
 	galleryVideoIDPattern = regexp.MustCompile(`(\d{19})`)
@@ -216,16 +217,15 @@ type Config struct {
 	CookieFromBrowser    string // Browser name (chrome, firefox, edge, safari, etc.)
 }
 
-
 // ToolConfig defines how to manage an external tool (yt-dlp, gallery-dl, etc.)
 type ToolConfig struct {
-	Name            string                                       // Display name (e.g., "yt-dlp")
-	ExeName         string                                       // Executable filename (e.g., "yt-dlp.exe")
-	GitHubRepo      string                                       // GitHub repo path (e.g., "yt-dlp/yt-dlp")
-	GetVersion      func(exePath string) (string, error)         // Get local version
-	CompareVersions func(local, remote string) int               // Compare versions
-	SelfUpdate      func(exePath string) error                   // Self-update command (nil if unsupported)
-	StripVPrefix    bool                                         // Strip "v" prefix from GitHub release tag
+	Name            string                               // Display name (e.g., "yt-dlp")
+	ExeName         string                               // Executable filename (e.g., "yt-dlp.exe")
+	GitHubRepo      string                               // GitHub repo path (e.g., "yt-dlp/yt-dlp")
+	GetVersion      func(exePath string) (string, error) // Get local version
+	CompareVersions func(local, remote string) int       // Compare versions
+	SelfUpdate      func(exePath string) error           // Self-update command (nil if unsupported)
+	StripVPrefix    bool                                 // Strip "v" prefix from GitHub release tag
 }
 
 // backupExe backs up the current executable to .old
@@ -597,21 +597,22 @@ func isPhotoPost(originalURL string, client *http.Client) (bool, string, error) 
 	// Set a user agent to avoid blocks
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
 
-	// Use the injected client but configure redirect handling to capture the final URL
-	// Save original redirect policy and restore after
-	originalCheckRedirect := client.CheckRedirect
+	// Create a per-request client to avoid mutating the shared client's CheckRedirect.
+	// This is safe for concurrent use since each goroutine gets its own client.
 	var finalURL string
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		finalURL = req.URL.String()
-		// Allow up to 10 redirects
-		if len(via) >= 10 {
-			return fmt.Errorf("too many redirects")
-		}
-		return nil
+	perRequestClient := &http.Client{
+		Transport: client.Transport,
+		Timeout:   15 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			finalURL = req.URL.String()
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
 	}
-	defer func() { client.CheckRedirect = originalCheckRedirect }()
 
-	resp, err := client.Do(req)
+	resp, err := perRequestClient.Do(req)
 	if err != nil {
 		// If we got a final URL from redirects before the error, use it
 		if finalURL != "" && strings.Contains(finalURL, "/photo/") {
@@ -629,6 +630,13 @@ func isPhotoPost(originalURL string, client *http.Client) (bool, string, error) 
 	// Check if the final URL contains /photo/
 	isPhoto := strings.Contains(finalURL, "/photo/")
 	return isPhoto, finalURL, nil
+}
+
+// detectionResult holds the result of detecting whether a URL is a video or photo.
+type detectionResult struct {
+	url         string
+	contentType string
+	err         error
 }
 
 // detectContentTypes detects whether each URL is a video or photo post.
@@ -671,45 +679,87 @@ func detectContentTypes(entries []VideoEntry, client *http.Client, cache map[str
 		fmt.Printf("[*] Detecting content types for %d URLs...\n", len(entries))
 	}
 
+	if len(uncached) == 0 {
+		return contentTypes
+	}
+
 	// Set up progress bar if supported and not disabled
 	useProgressBar := !disableProgressBar && supportsANSI()
 	renderer := &ProgressRenderer{
 		enabled: useProgressBar,
 	}
 
-	// Process only uncached URLs to detect photos vs videos
+	// Process uncached URLs using a worker pool.
+	// 10 workers share a rate limiter ticker at 50ms. Each tick is consumed by exactly
+	// one worker (Go channel semantics), capping the aggregate rate at 20 req/s.
 	photoCount := 0
 	videoCount := 0
 	errorCount := 0
+	processed := 0
 
-	for i, entry := range uncached {
-		if useProgressBar {
-			renderer.renderDetectionProgress(i+1, len(uncached), videoCount, photoCount, errorCount)
-		} else {
-			// Fallback: show progress every 50 URLs
-			if (i+1)%50 == 0 || i == len(uncached)-1 {
-				fmt.Printf("[*] Checking URL %d/%d...\r", i+1, len(uncached))
+	const numWorkers = 10
+	jobs := make(chan VideoEntry, numWorkers*2)
+	results := make(chan detectionResult, numWorkers*2)
+
+	rateLimiter := time.NewTicker(50 * time.Millisecond)
+	defer rateLimiter.Stop()
+
+	// Launch workers
+	var wg sync.WaitGroup
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for entry := range jobs {
+				<-rateLimiter.C
+
+				isPhoto, _, err := isPhotoPost(entry.Link, client)
+				if err != nil {
+					results <- detectionResult{url: entry.Link, contentType: "video", err: err}
+					continue
+				}
+				ct := "video"
+				if isPhoto {
+					ct = "photo"
+				}
+				results <- detectionResult{url: entry.Link, contentType: ct}
 			}
-		}
+		}()
+	}
 
-		isPhoto, _, err := isPhotoPost(entry.Link, client)
-		if err != nil {
-			// On error, default to video (yt-dlp will handle it)
-			contentTypes[entry.Link] = "video"
+	// Send jobs
+	go func() {
+		for _, entry := range uncached {
+			jobs <- entry
+		}
+		close(jobs)
+	}()
+
+	// Close results channel when all workers finish
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Collect results from a single goroutine (no mutex needed for contentTypes or progress)
+	for result := range results {
+		contentTypes[result.url] = result.contentType
+		if result.err != nil {
 			errorCount++
-			continue
-		}
-
-		if isPhoto {
-			contentTypes[entry.Link] = "photo"
+		} else if result.contentType == "photo" {
 			photoCount++
 		} else {
-			contentTypes[entry.Link] = "video"
 			videoCount++
 		}
+		processed++
 
-		// Small delay to avoid rate limiting (100ms between requests)
-		time.Sleep(100 * time.Millisecond)
+		if useProgressBar {
+			renderer.renderDetectionProgress(processed, len(uncached), videoCount, photoCount, errorCount)
+		} else {
+			if processed%50 == 0 || processed == len(uncached) {
+				fmt.Printf("[*] Checking URL %d/%d...\r", processed, len(uncached))
+			}
+		}
 	}
 
 	// Render final state and clear progress bar

--- a/generate_tiktok_links.go
+++ b/generate_tiktok_links.go
@@ -1082,10 +1082,6 @@ func writeFavoriteVideosToFile(videoEntries []VideoEntry, outputName string, org
 				fmt.Printf("[*] Extracted %d photo URLs to '%s'\n", len(photos), photoOutputName)
 			}
 
-			// If no photos, still show total for backward compatibility
-			if len(photos) == 0 && len(videos) > 0 {
-				// Already printed above
-			}
 		}
 	} else {
 		// Flat structure - separate videos and photos
@@ -2231,9 +2227,10 @@ func generateCollectionIndex(collectionDir string, entries []VideoEntry, failure
 				var imageFiles []string
 				for _, match := range matches {
 					ext := strings.ToLower(filepath.Ext(match))
-					if ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".webp" {
+					switch ext {
+					case ".jpg", ".jpeg", ".png", ".webp":
 						imageFiles = append(imageFiles, filepath.Base(match))
-					} else if ext == ".m4a" || ext == ".mp3" {
+					case ".m4a", ".mp3":
 						enrichedEntries[i].AudioFile = filepath.Base(match)
 					}
 				}

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -4962,8 +4962,9 @@ func TestDetectContentTypes(t *testing.T) {
 	t.Run("empty entries", func(t *testing.T) {
 		entries := []VideoEntry{}
 		client := &http.Client{}
+		cache := make(map[string]string)
 
-		result := detectContentTypes(entries, client)
+		result := detectContentTypes(entries, client, cache)
 		if len(result) != 0 {
 			t.Errorf("expected empty map, got %d entries", len(result))
 		}
@@ -4975,8 +4976,9 @@ func TestDetectContentTypes(t *testing.T) {
 			{Link: "https://www.tiktok.com/@user/video/456", ContentType: "video"},
 		}
 		client := &http.Client{}
+		cache := make(map[string]string)
 
-		result := detectContentTypes(entries, client)
+		result := detectContentTypes(entries, client, cache)
 
 		// Should still process and return content types
 		if len(result) != 2 {
@@ -4993,11 +4995,179 @@ func TestDetectContentTypes(t *testing.T) {
 		client := &http.Client{
 			Transport: &errorTransport{err: fmt.Errorf("should not be called")},
 		}
+		cache := make(map[string]string)
 
-		result := detectContentTypes(entries, client)
+		result := detectContentTypes(entries, client, cache)
 
 		if result[entries[0].Link] != "photo" {
 			t.Errorf("expected 'photo' content type, got %q", result[entries[0].Link])
+		}
+	})
+
+	t.Run("cached entries skip network requests", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktokv.com/share/video/111"},
+			{Link: "https://www.tiktokv.com/share/video/222"},
+		}
+
+		// Client that fails on any request - should NOT be called since all entries are cached
+		client := &http.Client{
+			Transport: &errorTransport{err: fmt.Errorf("should not be called for cached URLs")},
+		}
+
+		cache := map[string]string{
+			"https://www.tiktokv.com/share/video/111": "video",
+			"https://www.tiktokv.com/share/video/222": "photo",
+		}
+
+		result := detectContentTypes(entries, client, cache)
+
+		if result["https://www.tiktokv.com/share/video/111"] != "video" {
+			t.Errorf("expected 'video', got %q", result["https://www.tiktokv.com/share/video/111"])
+		}
+		if result["https://www.tiktokv.com/share/video/222"] != "photo" {
+			t.Errorf("expected 'photo', got %q", result["https://www.tiktokv.com/share/video/222"])
+		}
+	})
+
+	t.Run("mix of cached and uncached entries", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktokv.com/share/video/111"},
+			{Link: "https://www.tiktok.com/@user/photo/222"},
+		}
+
+		// Client that fails - the uncached URL contains /photo/ so no network needed
+		client := &http.Client{
+			Transport: &errorTransport{err: fmt.Errorf("should not be called")},
+		}
+
+		cache := map[string]string{
+			"https://www.tiktokv.com/share/video/111": "video",
+		}
+
+		result := detectContentTypes(entries, client, cache)
+
+		if len(result) != 2 {
+			t.Errorf("expected 2 entries, got %d", len(result))
+		}
+		if result["https://www.tiktokv.com/share/video/111"] != "video" {
+			t.Errorf("expected cached 'video', got %q", result["https://www.tiktokv.com/share/video/111"])
+		}
+		if result["https://www.tiktok.com/@user/photo/222"] != "photo" {
+			t.Errorf("expected detected 'photo', got %q", result["https://www.tiktok.com/@user/photo/222"])
+		}
+	})
+}
+
+func TestContentTypeCache(t *testing.T) {
+	t.Run("load and save round-trip", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "content_types_cache.json")
+
+		original := map[string]string{
+			"https://www.tiktokv.com/share/video/111": "video",
+			"https://www.tiktokv.com/share/video/222": "photo",
+			"https://www.tiktokv.com/share/video/333": "video",
+		}
+
+		err := saveContentTypeCache(cacheFile, original)
+		if err != nil {
+			t.Fatalf("saveContentTypeCache failed: %v", err)
+		}
+
+		loaded := loadContentTypeCache(cacheFile)
+
+		if len(loaded) != len(original) {
+			t.Fatalf("expected %d entries, got %d", len(original), len(loaded))
+		}
+		for url, ct := range original {
+			if loaded[url] != ct {
+				t.Errorf("URL %s: expected %q, got %q", url, ct, loaded[url])
+			}
+		}
+	})
+
+	t.Run("load missing file returns empty map", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "nonexistent.json")
+
+		loaded := loadContentTypeCache(cacheFile)
+
+		if len(loaded) != 0 {
+			t.Errorf("expected empty map for missing file, got %d entries", len(loaded))
+		}
+	})
+
+	t.Run("load corrupt file returns empty map", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "corrupt.json")
+
+		err := os.WriteFile(cacheFile, []byte("not valid json{{{"), 0644)
+		if err != nil {
+			t.Fatalf("failed to write corrupt file: %v", err)
+		}
+
+		loaded := loadContentTypeCache(cacheFile)
+
+		if len(loaded) != 0 {
+			t.Errorf("expected empty map for corrupt file, got %d entries", len(loaded))
+		}
+	})
+
+	t.Run("load file with null types returns empty map", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "null_types.json")
+
+		err := os.WriteFile(cacheFile, []byte(`{"version":1,"types":null}`), 0644)
+		if err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+
+		loaded := loadContentTypeCache(cacheFile)
+
+		if loaded == nil {
+			t.Error("expected non-nil map, got nil")
+		}
+		if len(loaded) != 0 {
+			t.Errorf("expected empty map, got %d entries", len(loaded))
+		}
+	})
+
+	t.Run("save to invalid path returns error", func(t *testing.T) {
+		err := saveContentTypeCache("/nonexistent/dir/cache.json", map[string]string{"a": "b"})
+		if err == nil {
+			t.Error("expected error when saving to invalid path, got nil")
+		}
+	})
+
+	t.Run("saved file has correct JSON structure", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "cache.json")
+
+		types := map[string]string{
+			"https://example.com/1": "video",
+		}
+
+		err := saveContentTypeCache(cacheFile, types)
+		if err != nil {
+			t.Fatalf("save failed: %v", err)
+		}
+
+		data, err := os.ReadFile(cacheFile)
+		if err != nil {
+			t.Fatalf("read failed: %v", err)
+		}
+
+		var cache ContentTypeCache
+		if err := json.Unmarshal(data, &cache); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+
+		if cache.Version != 1 {
+			t.Errorf("expected version 1, got %d", cache.Version)
+		}
+		if cache.Types["https://example.com/1"] != "video" {
+			t.Errorf("expected 'video', got %q", cache.Types["https://example.com/1"])
 		}
 	})
 }

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -4385,3 +4385,619 @@ func TestWriteFavoriteVideosToFileWithPhotos(t *testing.T) {
 		t.Errorf("expected 1 photo URL, got %d", len(photoLines))
 	}
 }
+
+// TestIsPhotoPost tests the photo post detection function
+func TestIsPhotoPost(t *testing.T) {
+	t.Run("URL already contains /photo/", func(t *testing.T) {
+		// URLs already containing /photo/ should return true immediately without HTTP request
+		photoURL := "https://www.tiktok.com/@user/photo/1234567890"
+		client := &http.Client{} // Won't be used since URL already contains /photo/
+
+		isPhoto, finalURL, err := isPhotoPost(photoURL, client)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !isPhoto {
+			t.Error("expected isPhoto to be true for URL containing /photo/")
+		}
+		if finalURL != photoURL {
+			t.Errorf("expected finalURL %q, got %q", photoURL, finalURL)
+		}
+	})
+
+	t.Run("video URL redirects to video", func(t *testing.T) {
+		// Create a test server that simulates TikTok's redirect behavior
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Simulate redirect to video URL
+			http.Redirect(w, r, "https://www.tiktok.com/@user/video/1234567890", http.StatusFound)
+		}))
+		defer server.Close()
+
+		client := server.Client()
+
+		isPhoto, finalURL, err := isPhotoPost(server.URL, client)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if isPhoto {
+			t.Error("expected isPhoto to be false for video URL")
+		}
+		if !strings.Contains(finalURL, "/video/") {
+			t.Errorf("expected finalURL to contain /video/, got %q", finalURL)
+		}
+	})
+
+	t.Run("video URL redirects to photo", func(t *testing.T) {
+		// Create a test server that simulates redirect to photo URL
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Simulate redirect to photo URL
+			http.Redirect(w, r, "https://www.tiktok.com/@user/photo/1234567890", http.StatusFound)
+		}))
+		defer server.Close()
+
+		client := server.Client()
+
+		isPhoto, finalURL, err := isPhotoPost(server.URL, client)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !isPhoto {
+			t.Error("expected isPhoto to be true for redirected photo URL")
+		}
+		if !strings.Contains(finalURL, "/photo/") {
+			t.Errorf("expected finalURL to contain /photo/, got %q", finalURL)
+		}
+	})
+
+	t.Run("URL without redirect", func(t *testing.T) {
+		// Create a test server that doesn't redirect
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := server.Client()
+
+		isPhoto, _, err := isPhotoPost(server.URL, client)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if isPhoto {
+			t.Error("expected isPhoto to be false for non-photo URL without redirect")
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		client := &http.Client{
+			Transport: &errorTransport{err: fmt.Errorf("network unreachable")},
+		}
+
+		_, _, err := isPhotoPost("https://www.tiktok.com/@user/video/123", client)
+		if err == nil {
+			t.Error("expected error for network failure, got nil")
+		}
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		client := &http.Client{}
+
+		_, _, err := isPhotoPost("://invalid-url", client)
+		if err == nil {
+			t.Error("expected error for invalid URL, got nil")
+		}
+	})
+
+	t.Run("multiple redirects to photo", func(t *testing.T) {
+		// Server that does multiple redirects before landing on a photo URL
+		redirectCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			redirectCount++
+			if redirectCount < 3 {
+				http.Redirect(w, r, r.URL.String(), http.StatusFound)
+			} else {
+				http.Redirect(w, r, "https://www.tiktok.com/@user/photo/123", http.StatusFound)
+			}
+		}))
+		defer server.Close()
+
+		client := server.Client()
+
+		isPhoto, finalURL, err := isPhotoPost(server.URL, client)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !isPhoto {
+			t.Error("expected isPhoto to be true after multiple redirects")
+		}
+		if !strings.Contains(finalURL, "/photo/") {
+			t.Errorf("expected finalURL to contain /photo/, got %q", finalURL)
+		}
+	})
+}
+
+// TestGetOrDownloadGalleryDl tests the gallery-dl download function
+func TestGetOrDownloadGalleryDl(t *testing.T) {
+	t.Run("file already exists", func(t *testing.T) {
+		// Create a temp directory
+		tmpDir, err := os.MkdirTemp("", "gallerydl_test")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		oldCwd, _ := os.Getwd()
+		defer func() { _ = os.Chdir(oldCwd) }()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		exeName := "gallery-dl.exe"
+
+		// Create a dummy file
+		if err := os.WriteFile(exeName, []byte("dummy gallery-dl"), 0644); err != nil {
+			t.Fatalf("failed to create dummy exe: %v", err)
+		}
+
+		// Should return nil when file exists (won't check version since it's a dummy)
+		client := http.DefaultClient
+		err = getOrDownloadGalleryDl(client, exeName)
+		if err != nil {
+			t.Errorf("expected nil error when file exists, got: %v", err)
+		}
+	})
+
+	t.Run("file does not exist - downloads successfully", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "gallerydl_download_test")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		oldCwd, _ := os.Getwd()
+		defer func() { _ = os.Chdir(oldCwd) }()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		exeName := "gallery-dl.exe"
+
+		// Create a mock release JSON
+		mockReleaseJSON := `{
+			"assets": [
+				{
+					"name": "gallery-dl.exe",
+					"browser_download_url": "http://example.com/gallery-dl.exe"
+				}
+			]
+		}`
+
+		// Create a test server
+		downloadHandler := http.NewServeMux()
+		downloadHandler.HandleFunc("/repos/mikf/gallery-dl/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+			if _, err := w.Write([]byte(mockReleaseJSON)); err != nil {
+				t.Errorf("failed to write mock release JSON: %v", err)
+			}
+		})
+		downloadHandler.HandleFunc("/gallery-dl.exe", func(w http.ResponseWriter, r *http.Request) {
+			if _, err := w.Write([]byte("fake gallery-dl exe content")); err != nil {
+				t.Errorf("failed to write fake exe: %v", err)
+			}
+		})
+		ts := httptest.NewServer(downloadHandler)
+		defer ts.Close()
+
+		// Use custom client that rewrites URLs to test server
+		customClient := &http.Client{
+			Transport: &rewriterRoundTripper{
+				rt:   http.DefaultTransport,
+				host: ts.URL,
+			},
+		}
+
+		err = getOrDownloadGalleryDl(customClient, exeName)
+		if err != nil {
+			t.Errorf("expected nil error on download, got: %v", err)
+		}
+
+		// Verify file was created
+		if _, err := os.Stat(exeName); os.IsNotExist(err) {
+			t.Errorf("expected %s to exist after download", exeName)
+		}
+	})
+
+	t.Run("download fails - no asset found", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "gallerydl_noasset_test")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		oldCwd, _ := os.Getwd()
+		defer func() { _ = os.Chdir(oldCwd) }()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		exeName := "gallery-dl.exe"
+
+		// Create a mock release JSON with wrong asset name
+		mockReleaseJSON := `{
+			"assets": [
+				{
+					"name": "wrong-name.exe",
+					"browser_download_url": "http://example.com/wrong.exe"
+				}
+			]
+		}`
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, err := w.Write([]byte(mockReleaseJSON)); err != nil {
+				t.Errorf("failed to write mock release JSON: %v", err)
+			}
+		}))
+		defer server.Close()
+
+		customClient := &http.Client{
+			Transport: &rewriterRoundTripper{
+				rt:   http.DefaultTransport,
+				host: server.URL,
+			},
+		}
+
+		err = getOrDownloadGalleryDl(customClient, exeName)
+		if err == nil {
+			t.Error("expected error when asset not found")
+		}
+	})
+}
+
+// GalleryDlMockCommandRunner is a mock command runner specifically for gallery-dl tests
+type GalleryDlMockCommandRunner struct {
+	ShouldFail    bool
+	Commands      []MockCommand
+	OutputLines   []string
+	ExpectedError error
+}
+
+func (m *GalleryDlMockCommandRunner) Run(name string, args ...string) (CapturedOutput, error) {
+	m.Commands = append(m.Commands, MockCommand{Name: name, Args: args})
+
+	output := CapturedOutput{
+		Combined: m.OutputLines,
+	}
+
+	if m.ShouldFail {
+		if m.ExpectedError != nil {
+			return output, m.ExpectedError
+		}
+		return output, fmt.Errorf("mock command failed")
+	}
+	return output, nil
+}
+
+// TestRunGalleryDlWithRunner tests the runGalleryDl function
+func TestRunGalleryDlWithRunner(t *testing.T) {
+	t.Run("empty entries returns immediately", func(t *testing.T) {
+		entries := []VideoEntry{}
+		result, err := runGalleryDl("", "test_dir", false, entries, "", "")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.Attempted != 0 {
+			t.Errorf("expected 0 attempted, got %d", result.Attempted)
+		}
+	})
+
+	t.Run("basic execution creates correct arguments", func(t *testing.T) {
+		// Create temp directory
+		tmpDir, err := os.MkdirTemp("", "gallery_dl_test_*")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/photo/123", VideoID: "123", ContentType: "photo"},
+		}
+
+		// Run with minimal settings - this will fail because gallery-dl.exe doesn't exist
+		// but we can verify the temp file creation and argument building
+		_, _ = runGalleryDl("", tmpDir, false, entries, "", "")
+
+		// Verify temp file was attempted (even if command failed)
+		// The function should have cleaned up the temp file on exit
+	})
+}
+
+// TestGetGalleryDlVersion tests the version parsing for gallery-dl
+func TestGetGalleryDlVersion(t *testing.T) {
+	// This test would require mocking exec.Command which is complex
+	// Instead, we test edge cases of the version parsing logic
+
+	t.Run("version parsing from output format", func(t *testing.T) {
+		// gallery-dl outputs "gallery-dl X.Y.Z"
+		// The function extracts the version number
+
+		// Simulate what the function does internally
+		testCases := []struct {
+			output   string
+			expected string
+		}{
+			{"gallery-dl 1.28.5", "1.28.5"},
+			{"gallery-dl 2.0.0", "2.0.0"},
+			{"gallery-dl 1.28.5-dev", "1.28.5-dev"},
+		}
+
+		for _, tc := range testCases {
+			// Simulate the parsing logic from getGalleryDlVersion
+			version := strings.TrimSpace(tc.output)
+			parts := strings.Fields(version)
+			var result string
+			if len(parts) >= 2 {
+				result = parts[len(parts)-1]
+			}
+			if result != tc.expected {
+				t.Errorf("parseVersion(%q) = %q, want %q", tc.output, result, tc.expected)
+			}
+		}
+	})
+}
+
+// TestGetLatestGalleryDlVersion tests fetching the latest gallery-dl version
+func TestGetLatestGalleryDlVersion(t *testing.T) {
+	t.Run("successful redirect parsing", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/mikf/gallery-dl/releases/latest" {
+				w.Header().Set("Location", "https://github.com/mikf/gallery-dl/releases/tag/v1.28.5")
+				w.WriteHeader(http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		client := server.Client()
+		// Override transport to redirect GitHub URLs to test server
+		client.Transport = &galleryDlRedirectTransport{
+			server:   server,
+			original: client.Transport,
+		}
+
+		version, err := getLatestGalleryDlVersion(client)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		// The function strips the "v" prefix, so expect "1.28.5"
+		if version != "1.28.5" {
+			t.Errorf("expected version 1.28.5, got %s", version)
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		client := &http.Client{
+			Transport: &errorTransport{err: fmt.Errorf("network unreachable")},
+		}
+
+		_, err := getLatestGalleryDlVersion(client)
+		if err == nil {
+			t.Error("expected error for network failure, got nil")
+		}
+	})
+}
+
+// galleryDlRedirectTransport rewrites GitHub gallery-dl URLs to the test server
+type galleryDlRedirectTransport struct {
+	server   *httptest.Server
+	original http.RoundTripper
+}
+
+func (t *galleryDlRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Host, "github.com") {
+		req.URL.Scheme = "http"
+		req.URL.Host = strings.TrimPrefix(t.server.URL, "http://")
+	}
+	if t.original != nil {
+		return t.original.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// TestDownloadLatestGalleryDl tests the gallery-dl download function
+func TestDownloadLatestGalleryDl(t *testing.T) {
+	t.Run("successful download", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "gallerydl_download_*")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		oldCwd, _ := os.Getwd()
+		defer func() { _ = os.Chdir(oldCwd) }()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		exeName := "gallery-dl.exe"
+		mockReleaseJSON := `{
+			"assets": [
+				{
+					"name": "gallery-dl.exe",
+					"browser_download_url": "http://example.com/gallery-dl.exe"
+				}
+			]
+		}`
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/mikf/gallery-dl/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+			if _, err := w.Write([]byte(mockReleaseJSON)); err != nil {
+				t.Errorf("failed to write: %v", err)
+			}
+		})
+		mux.HandleFunc("/gallery-dl.exe", func(w http.ResponseWriter, r *http.Request) {
+			if _, err := w.Write([]byte("fake exe content")); err != nil {
+				t.Errorf("failed to write: %v", err)
+			}
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		client := &http.Client{
+			Transport: &rewriterRoundTripper{
+				rt:   http.DefaultTransport,
+				host: server.URL,
+			},
+		}
+
+		err = downloadLatestGalleryDl(client, exeName)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// Verify file was created
+		if _, err := os.Stat(exeName); os.IsNotExist(err) {
+			t.Error("gallery-dl.exe should have been created")
+		}
+	})
+
+	t.Run("invalid JSON response", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "gallerydl_invalid_*")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		oldCwd, _ := os.Getwd()
+		defer func() { _ = os.Chdir(oldCwd) }()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, err := w.Write([]byte("not valid json")); err != nil {
+				t.Errorf("failed to write: %v", err)
+			}
+		}))
+		defer server.Close()
+
+		client := &http.Client{
+			Transport: &rewriterRoundTripper{
+				rt:   http.DefaultTransport,
+				host: server.URL,
+			},
+		}
+
+		err = downloadLatestGalleryDl(client, "gallery-dl.exe")
+		if err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+	})
+}
+
+// TestBackupGalleryDl tests the gallery-dl backup function
+func TestBackupGalleryDl(t *testing.T) {
+	t.Run("successful backup", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "backup_gallerydl_*")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		oldCwd, _ := os.Getwd()
+		defer func() { _ = os.Chdir(oldCwd) }()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		exeName := "gallery-dl.exe"
+		content := []byte("gallery-dl content")
+		if err := os.WriteFile(exeName, content, 0644); err != nil {
+			t.Fatalf("failed to create exe: %v", err)
+		}
+
+		err = backupGalleryDl(exeName)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// Verify backup exists
+		backupContent, err := os.ReadFile(exeName + ".old")
+		if err != nil {
+			t.Errorf("failed to read backup: %v", err)
+		}
+		if string(backupContent) != string(content) {
+			t.Errorf("backup content mismatch")
+		}
+
+		// Verify original is gone
+		if _, err := os.Stat(exeName); !os.IsNotExist(err) {
+			t.Error("original should be renamed")
+		}
+	})
+
+	t.Run("backup non-existent file", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "backup_nofile_*")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		oldCwd, _ := os.Getwd()
+		defer func() { _ = os.Chdir(oldCwd) }()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+
+		err = backupGalleryDl("nonexistent.exe")
+		if err == nil {
+			t.Error("expected error for non-existent file")
+		}
+	})
+}
+
+// TestDetectContentTypes tests batch content type detection
+func TestDetectContentTypes(t *testing.T) {
+	t.Run("empty entries", func(t *testing.T) {
+		entries := []VideoEntry{}
+		client := &http.Client{}
+
+		result := detectContentTypes(entries, client)
+		if len(result) != 0 {
+			t.Errorf("expected empty map, got %d entries", len(result))
+		}
+	})
+
+	t.Run("entries already typed", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/photo/123", ContentType: "photo"},
+			{Link: "https://www.tiktok.com/@user/video/456", ContentType: "video"},
+		}
+		client := &http.Client{}
+
+		result := detectContentTypes(entries, client)
+
+		// Should still process and return content types
+		if len(result) != 2 {
+			t.Errorf("expected 2 entries, got %d", len(result))
+		}
+	})
+
+	t.Run("URL with /photo/ detected without network", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/photo/123"},
+		}
+
+		// Use a client that fails on any request - shouldn't be called for /photo/ URLs
+		client := &http.Client{
+			Transport: &errorTransport{err: fmt.Errorf("should not be called")},
+		}
+
+		result := detectContentTypes(entries, client)
+
+		if result[entries[0].Link] != "photo" {
+			t.Errorf("expected 'photo' content type, got %q", result[entries[0].Link])
+		}
+	})
+}

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -10,9 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 )
@@ -3584,62 +3582,6 @@ func TestProgressRenderer(t *testing.T) {
 }
 
 // TestRenderDetectionProgress tests the detection progress bar rendering
-func TestRenderDetectionProgress(t *testing.T) {
-	t.Run("disabled renderer produces no output", func(t *testing.T) {
-		var buf bytes.Buffer
-		renderer := &ProgressRenderer{enabled: false, writer: &buf}
-
-		renderer.renderDetectionProgress(50, 100, 40, 8, 2)
-
-		if buf.Len() != 0 {
-			t.Errorf("expected no output when disabled, got %q", buf.String())
-		}
-	})
-
-	t.Run("enabled renderer writes expected format", func(t *testing.T) {
-		var buf bytes.Buffer
-		renderer := &ProgressRenderer{enabled: true, writer: &buf}
-
-		renderer.renderDetectionProgress(50, 100, 40, 8, 2)
-
-		output := buf.String()
-		if !strings.Contains(output, "Detecting content types (50/100)") {
-			t.Errorf("expected progress count in output, got %q", output)
-		}
-		if !strings.Contains(output, "50.0%%") {
-			// Check for percentage (note: Sprintf uses %% for literal %)
-			if !strings.Contains(output, "50.0%") {
-				t.Errorf("expected percentage in output, got %q", output)
-			}
-		}
-		if !strings.Contains(output, "Videos: 40") {
-			t.Errorf("expected video count in output, got %q", output)
-		}
-		if !strings.Contains(output, "Photos: 8") {
-			t.Errorf("expected photo count in output, got %q", output)
-		}
-		if !strings.Contains(output, "Errors: 2") {
-			t.Errorf("expected error count in output, got %q", output)
-		}
-	})
-
-	t.Run("progress bar fills correctly at 100%", func(t *testing.T) {
-		var buf bytes.Buffer
-		renderer := &ProgressRenderer{enabled: true, writer: &buf}
-
-		renderer.renderDetectionProgress(100, 100, 90, 10, 0)
-
-		output := buf.String()
-		if !strings.Contains(output, "100.0%") {
-			t.Errorf("expected 100%% in output, got %q", output)
-		}
-		// Should have full bar (20 filled blocks)
-		if !strings.Contains(output, strings.Repeat("█", 20)) {
-			t.Errorf("expected full progress bar, got %q", output)
-		}
-	})
-}
-
 // TestParseArchiveFile tests the parseArchiveFile function with various inputs
 func TestParseArchiveFile(t *testing.T) {
 	tests := []struct {
@@ -4404,182 +4346,6 @@ func TestWriteFavoriteVideosToFileWithPhotos(t *testing.T) {
 }
 
 // TestIsPhotoPost tests the photo post detection function
-func TestIsPhotoPost(t *testing.T) {
-	t.Run("URL already contains /photo/", func(t *testing.T) {
-		// URLs already containing /photo/ should return true immediately without HTTP request
-		photoURL := "https://www.tiktok.com/@user/photo/1234567890"
-		client := &http.Client{} // Won't be used since URL already contains /photo/
-
-		isPhoto, finalURL, err := isPhotoPost(photoURL, client)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !isPhoto {
-			t.Error("expected isPhoto to be true for URL containing /photo/")
-		}
-		if finalURL != photoURL {
-			t.Errorf("expected finalURL %q, got %q", photoURL, finalURL)
-		}
-	})
-
-	t.Run("video URL redirects to video", func(t *testing.T) {
-		// Create a test server that simulates TikTok's redirect behavior
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Simulate redirect to video URL
-			http.Redirect(w, r, "https://www.tiktok.com/@user/video/1234567890", http.StatusFound)
-		}))
-		defer server.Close()
-
-		client := server.Client()
-
-		isPhoto, finalURL, err := isPhotoPost(server.URL, client)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if isPhoto {
-			t.Error("expected isPhoto to be false for video URL")
-		}
-		if !strings.Contains(finalURL, "/video/") {
-			t.Errorf("expected finalURL to contain /video/, got %q", finalURL)
-		}
-	})
-
-	t.Run("video URL redirects to photo", func(t *testing.T) {
-		// Create a test server that simulates redirect to photo URL
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Simulate redirect to photo URL
-			http.Redirect(w, r, "https://www.tiktok.com/@user/photo/1234567890", http.StatusFound)
-		}))
-		defer server.Close()
-
-		client := server.Client()
-
-		isPhoto, finalURL, err := isPhotoPost(server.URL, client)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !isPhoto {
-			t.Error("expected isPhoto to be true for redirected photo URL")
-		}
-		if !strings.Contains(finalURL, "/photo/") {
-			t.Errorf("expected finalURL to contain /photo/, got %q", finalURL)
-		}
-	})
-
-	t.Run("URL without redirect", func(t *testing.T) {
-		// Create a test server that doesn't redirect
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer server.Close()
-
-		client := server.Client()
-
-		isPhoto, _, err := isPhotoPost(server.URL, client)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if isPhoto {
-			t.Error("expected isPhoto to be false for non-photo URL without redirect")
-		}
-	})
-
-	t.Run("network error", func(t *testing.T) {
-		client := &http.Client{
-			Transport: &errorTransport{err: fmt.Errorf("network unreachable")},
-		}
-
-		_, _, err := isPhotoPost("https://www.tiktok.com/@user/video/123", client)
-		if err == nil {
-			t.Error("expected error for network failure, got nil")
-		}
-	})
-
-	t.Run("invalid URL", func(t *testing.T) {
-		client := &http.Client{}
-
-		_, _, err := isPhotoPost("://invalid-url", client)
-		if err == nil {
-			t.Error("expected error for invalid URL, got nil")
-		}
-	})
-
-	t.Run("multiple redirects to photo", func(t *testing.T) {
-		// Server that does multiple redirects before landing on a photo URL
-		redirectCount := 0
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			redirectCount++
-			if redirectCount < 3 {
-				http.Redirect(w, r, r.URL.String(), http.StatusFound)
-			} else {
-				http.Redirect(w, r, "https://www.tiktok.com/@user/photo/123", http.StatusFound)
-			}
-		}))
-		defer server.Close()
-
-		client := server.Client()
-
-		isPhoto, finalURL, err := isPhotoPost(server.URL, client)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !isPhoto {
-			t.Error("expected isPhoto to be true after multiple redirects")
-		}
-		if !strings.Contains(finalURL, "/photo/") {
-			t.Errorf("expected finalURL to contain /photo/, got %q", finalURL)
-		}
-	})
-
-	t.Run("concurrent calls are race-free", func(t *testing.T) {
-		// Verify that isPhotoPost can be called concurrently on the same
-		// *http.Client without data races (requires -race flag to verify).
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Alternate between photo and video redirects based on a query param
-			if r.URL.Query().Get("type") == "photo" {
-				http.Redirect(w, r, "https://www.tiktok.com/@user/photo/"+r.URL.Query().Get("id"), http.StatusFound)
-			} else {
-				http.Redirect(w, r, "https://www.tiktok.com/@user/video/"+r.URL.Query().Get("id"), http.StatusFound)
-			}
-		}))
-		defer server.Close()
-
-		client := server.Client()
-
-		const goroutines = 50
-		var wg sync.WaitGroup
-		wg.Add(goroutines)
-		errs := make(chan error, goroutines)
-
-		for i := 0; i < goroutines; i++ {
-			go func(idx int) {
-				defer wg.Done()
-				urlType := "video"
-				if idx%2 == 0 {
-					urlType = "photo"
-				}
-				url := server.URL + "?type=" + urlType + "&id=" + strconv.Itoa(idx)
-				isPhoto, _, err := isPhotoPost(url, client)
-				if err != nil {
-					errs <- fmt.Errorf("goroutine %d: unexpected error: %v", idx, err)
-					return
-				}
-				if urlType == "photo" && !isPhoto {
-					errs <- fmt.Errorf("goroutine %d: expected photo, got video", idx)
-				} else if urlType == "video" && isPhoto {
-					errs <- fmt.Errorf("goroutine %d: expected video, got photo", idx)
-				}
-			}(i)
-		}
-
-		wg.Wait()
-		close(errs)
-		for err := range errs {
-			t.Error(err)
-		}
-	})
-}
-
 // TestGetOrDownloadGalleryDl tests the gallery-dl download function
 func TestGetOrDownloadGalleryDl(t *testing.T) {
 	t.Run("file already exists", func(t *testing.T) {
@@ -5042,135 +4808,6 @@ func TestBackupGalleryDl(t *testing.T) {
 }
 
 // TestDetectContentTypes tests batch content type detection
-func TestDetectContentTypes(t *testing.T) {
-	t.Run("empty entries", func(t *testing.T) {
-		entries := []VideoEntry{}
-		client := &http.Client{}
-		cache := make(map[string]string)
-
-		result := detectContentTypes(entries, client, cache, true)
-		if len(result) != 0 {
-			t.Errorf("expected empty map, got %d entries", len(result))
-		}
-	})
-
-	t.Run("photo URL in path detected without network", func(t *testing.T) {
-		// isPhotoPost returns true immediately for URLs containing /photo/ —
-		// no HTTP request needed. Only /photo/ URLs get the early return;
-		// /video/ URLs still require a network call to follow redirects.
-		entries := []VideoEntry{
-			{Link: "https://www.tiktok.com/@user/photo/123"},
-		}
-		client := &http.Client{
-			Transport: &errorTransport{err: fmt.Errorf("should not be called")},
-		}
-		cache := make(map[string]string)
-
-		result := detectContentTypes(entries, client, cache, true)
-
-		if len(result) != 1 {
-			t.Errorf("expected 1 entry, got %d", len(result))
-		}
-		if result["https://www.tiktok.com/@user/photo/123"] != "photo" {
-			t.Errorf("expected 'photo', got %q", result["https://www.tiktok.com/@user/photo/123"])
-		}
-	})
-
-	t.Run("cached entries skip network requests", func(t *testing.T) {
-		entries := []VideoEntry{
-			{Link: "https://www.tiktokv.com/share/video/111"},
-			{Link: "https://www.tiktokv.com/share/video/222"},
-		}
-
-		// Client that fails on any request - should NOT be called since all entries are cached
-		client := &http.Client{
-			Transport: &errorTransport{err: fmt.Errorf("should not be called for cached URLs")},
-		}
-
-		cache := map[string]string{
-			"https://www.tiktokv.com/share/video/111": "video",
-			"https://www.tiktokv.com/share/video/222": "photo",
-		}
-
-		result := detectContentTypes(entries, client, cache, true)
-
-		if result["https://www.tiktokv.com/share/video/111"] != "video" {
-			t.Errorf("expected 'video', got %q", result["https://www.tiktokv.com/share/video/111"])
-		}
-		if result["https://www.tiktokv.com/share/video/222"] != "photo" {
-			t.Errorf("expected 'photo', got %q", result["https://www.tiktokv.com/share/video/222"])
-		}
-	})
-
-	t.Run("redirect-based detection through worker pool", func(t *testing.T) {
-		// Integration test: exercises the full worker pool with actual HTTP redirects.
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/short/1":
-				http.Redirect(w, r, "https://www.tiktok.com/@user/photo/1001", http.StatusFound)
-			case "/short/2":
-				http.Redirect(w, r, "https://www.tiktok.com/@user/video/1002", http.StatusFound)
-			case "/short/3":
-				http.Redirect(w, r, "https://www.tiktok.com/@user/photo/1003", http.StatusFound)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-		defer server.Close()
-
-		entries := []VideoEntry{
-			{Link: server.URL + "/short/1"},
-			{Link: server.URL + "/short/2"},
-			{Link: server.URL + "/short/3"},
-		}
-		client := server.Client()
-		cache := make(map[string]string)
-
-		result := detectContentTypes(entries, client, cache, true)
-
-		if len(result) != 3 {
-			t.Fatalf("expected 3 entries, got %d", len(result))
-		}
-		if result[entries[0].Link] != "photo" {
-			t.Errorf("entry 0: expected 'photo', got %q", result[entries[0].Link])
-		}
-		if result[entries[1].Link] != "video" {
-			t.Errorf("entry 1: expected 'video', got %q", result[entries[1].Link])
-		}
-		if result[entries[2].Link] != "photo" {
-			t.Errorf("entry 2: expected 'photo', got %q", result[entries[2].Link])
-		}
-	})
-
-	t.Run("mix of cached and uncached entries", func(t *testing.T) {
-		entries := []VideoEntry{
-			{Link: "https://www.tiktokv.com/share/video/111"},
-			{Link: "https://www.tiktok.com/@user/photo/222"},
-		}
-
-		// Client that fails - the uncached URL contains /photo/ so no network needed
-		client := &http.Client{
-			Transport: &errorTransport{err: fmt.Errorf("should not be called")},
-		}
-
-		cache := map[string]string{
-			"https://www.tiktokv.com/share/video/111": "video",
-		}
-
-		result := detectContentTypes(entries, client, cache, true)
-
-		if len(result) != 2 {
-			t.Errorf("expected 2 entries, got %d", len(result))
-		}
-		if result["https://www.tiktokv.com/share/video/111"] != "video" {
-			t.Errorf("expected cached 'video', got %q", result["https://www.tiktokv.com/share/video/111"])
-		}
-		if result["https://www.tiktok.com/@user/photo/222"] != "photo" {
-			t.Errorf("expected detected 'photo', got %q", result["https://www.tiktok.com/@user/photo/222"])
-		}
-	})
-}
-
 func TestContentTypeCache(t *testing.T) {
 	t.Run("load and save round-trip", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -5280,6 +4917,368 @@ func TestContentTypeCache(t *testing.T) {
 		}
 		if cache.Types["https://example.com/1"] != "video" {
 			t.Errorf("expected 'video', got %q", cache.Types["https://example.com/1"])
+		}
+	})
+}
+
+func TestIdentifyFailedEntries(t *testing.T) {
+	t.Run("all succeeded", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/video/1001"},
+			{Link: "https://www.tiktok.com/@user/video/1002"},
+		}
+		before := map[string]bool{}
+		after := map[string]bool{"1001": true, "1002": true}
+
+		succeeded, alreadyDownloaded, failed := identifyFailedEntries(entries, before, after)
+		if len(succeeded) != 2 {
+			t.Errorf("expected 2 succeeded, got %d", len(succeeded))
+		}
+		if len(alreadyDownloaded) != 0 {
+			t.Errorf("expected 0 already downloaded, got %d", len(alreadyDownloaded))
+		}
+		if len(failed) != 0 {
+			t.Errorf("expected 0 failed, got %d", len(failed))
+		}
+	})
+
+	t.Run("all already downloaded", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/video/1001"},
+			{Link: "https://www.tiktok.com/@user/video/1002"},
+		}
+		before := map[string]bool{"1001": true, "1002": true}
+		after := map[string]bool{"1001": true, "1002": true}
+
+		succeeded, alreadyDownloaded, failed := identifyFailedEntries(entries, before, after)
+		if len(succeeded) != 0 {
+			t.Errorf("expected 0 succeeded, got %d", len(succeeded))
+		}
+		if len(alreadyDownloaded) != 2 {
+			t.Errorf("expected 2 already downloaded, got %d", len(alreadyDownloaded))
+		}
+		if len(failed) != 0 {
+			t.Errorf("expected 0 failed, got %d", len(failed))
+		}
+	})
+
+	t.Run("all failed", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/video/1001"},
+			{Link: "https://www.tiktok.com/@user/video/1002"},
+		}
+		before := map[string]bool{}
+		after := map[string]bool{}
+
+		succeeded, alreadyDownloaded, failed := identifyFailedEntries(entries, before, after)
+		if len(succeeded) != 0 {
+			t.Errorf("expected 0 succeeded, got %d", len(succeeded))
+		}
+		if len(alreadyDownloaded) != 0 {
+			t.Errorf("expected 0 already downloaded, got %d", len(alreadyDownloaded))
+		}
+		if len(failed) != 2 {
+			t.Errorf("expected 2 failed, got %d", len(failed))
+		}
+	})
+
+	t.Run("mixed results", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/video/1001"}, // will succeed
+			{Link: "https://www.tiktok.com/@user/video/1002"}, // already downloaded
+			{Link: "https://www.tiktok.com/@user/video/1003"}, // will fail
+		}
+		before := map[string]bool{"1002": true}
+		after := map[string]bool{"1001": true, "1002": true}
+
+		succeeded, alreadyDownloaded, failed := identifyFailedEntries(entries, before, after)
+		if len(succeeded) != 1 || extractVideoID(succeeded[0].Link) != "1001" {
+			t.Errorf("expected succeeded=[1001], got %v", succeeded)
+		}
+		if len(alreadyDownloaded) != 1 || extractVideoID(alreadyDownloaded[0].Link) != "1002" {
+			t.Errorf("expected alreadyDownloaded=[1002], got %v", alreadyDownloaded)
+		}
+		if len(failed) != 1 || extractVideoID(failed[0].Link) != "1003" {
+			t.Errorf("expected failed=[1003], got %v", failed)
+		}
+	})
+
+	t.Run("unparseable URL goes to failed", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://invalid-url-no-id"},
+		}
+		before := map[string]bool{}
+		after := map[string]bool{}
+
+		_, _, failed := identifyFailedEntries(entries, before, after)
+		if len(failed) != 1 {
+			t.Errorf("expected 1 failed for unparseable URL, got %d", len(failed))
+		}
+	})
+}
+
+func TestInferContentTypeFromFiles(t *testing.T) {
+	t.Run("detects video from info.json", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		videoID := "7600559584901647646"
+		// Create a .info.json file
+		infoFile := filepath.Join(tmpDir, "20260129_"+videoID+"_Test.info.json")
+		if err := os.WriteFile(infoFile, []byte(`{"id":"7600559584901647646"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ct := inferContentTypeFromFiles(tmpDir, videoID)
+		if ct != "video" {
+			t.Errorf("expected 'video', got %q", ct)
+		}
+	})
+
+	t.Run("detects video from mp4 file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		videoID := "7600559584901647646"
+		mp4File := filepath.Join(tmpDir, "20260129_"+videoID+"_Test.mp4")
+		if err := os.WriteFile(mp4File, []byte("fake video"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ct := inferContentTypeFromFiles(tmpDir, videoID)
+		if ct != "video" {
+			t.Errorf("expected 'video', got %q", ct)
+		}
+	})
+
+	t.Run("detects photo from jpg file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		videoID := "7597601281703693623"
+		jpgFile := filepath.Join(tmpDir, "20260129_"+videoID+"_Slideshow_1.jpg")
+		if err := os.WriteFile(jpgFile, []byte("fake image"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ct := inferContentTypeFromFiles(tmpDir, videoID)
+		if ct != "photo" {
+			t.Errorf("expected 'photo', got %q", ct)
+		}
+	})
+
+	t.Run("detects photo from gallery-dl json", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		videoID := "7597601281703693623"
+		jsonFile := filepath.Join(tmpDir, "20260129_"+videoID+"_Slideshow.json")
+		if err := os.WriteFile(jsonFile, []byte(`{"id":"7597601281703693623"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ct := inferContentTypeFromFiles(tmpDir, videoID)
+		if ct != "photo" {
+			t.Errorf("expected 'photo', got %q", ct)
+		}
+	})
+
+	t.Run("returns empty for no files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		ct := inferContentTypeFromFiles(tmpDir, "9999999999999999999")
+		if ct != "" {
+			t.Errorf("expected empty string, got %q", ct)
+		}
+	})
+
+	t.Run("returns empty for empty video ID", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		ct := inferContentTypeFromFiles(tmpDir, "")
+		if ct != "" {
+			t.Errorf("expected empty string for empty videoID, got %q", ct)
+		}
+	})
+
+	t.Run("info.json takes priority over photo files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		videoID := "7600559584901647646"
+		// Create both .info.json and .jpg (info.json should win => video)
+		infoFile := filepath.Join(tmpDir, "20260129_"+videoID+"_Test.info.json")
+		if err := os.WriteFile(infoFile, []byte(`{"id":"test"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		jpgFile := filepath.Join(tmpDir, "20260129_"+videoID+"_Test.jpg")
+		if err := os.WriteFile(jpgFile, []byte("fake"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ct := inferContentTypeFromFiles(tmpDir, videoID)
+		if ct != "video" {
+			t.Errorf("expected 'video' (info.json priority), got %q", ct)
+		}
+	})
+}
+
+func TestApplyContentTypesFromCache(t *testing.T) {
+	t.Run("applies cached types", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/video/1001"},
+			{Link: "https://www.tiktok.com/@user/video/1002"},
+		}
+		cache := map[string]string{
+			"https://www.tiktok.com/@user/video/1001": "video",
+			"https://www.tiktok.com/@user/video/1002": "photo",
+		}
+
+		unknown := applyContentTypesFromCache(entries, cache, ".", false)
+		if unknown != 0 {
+			t.Errorf("expected 0 unknown, got %d", unknown)
+		}
+		if entries[0].ContentType != "video" {
+			t.Errorf("expected 'video', got %q", entries[0].ContentType)
+		}
+		if entries[1].ContentType != "photo" {
+			t.Errorf("expected 'photo', got %q", entries[1].ContentType)
+		}
+	})
+
+	t.Run("infers from files on disk", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		videoID := "7600559584901647646"
+		// Create a .info.json file in the temp directory
+		infoFile := filepath.Join(tmpDir, "20260129_"+videoID+"_Test.info.json")
+		if err := os.WriteFile(infoFile, []byte(`{"id":"test"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/video/" + videoID},
+		}
+		cache := make(map[string]string)
+
+		unknown := applyContentTypesFromCache(entries, cache, tmpDir, false)
+		if unknown != 0 {
+			t.Errorf("expected 0 unknown, got %d", unknown)
+		}
+		if entries[0].ContentType != "video" {
+			t.Errorf("expected 'video', got %q", entries[0].ContentType)
+		}
+		// Cache should also be updated
+		if cache[entries[0].Link] != "video" {
+			t.Errorf("expected cache to be updated with 'video'")
+		}
+	})
+
+	t.Run("counts truly unknown entries", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/video/1001"},
+			{Link: "https://www.tiktok.com/@user/video/1002"},
+		}
+		cache := map[string]string{
+			"https://www.tiktok.com/@user/video/1001": "video",
+		}
+
+		tmpDir := t.TempDir()
+		unknown := applyContentTypesFromCache(entries, cache, tmpDir, false)
+		if unknown != 1 {
+			t.Errorf("expected 1 unknown, got %d", unknown)
+		}
+	})
+
+	t.Run("skips entries that already have ContentType", func(t *testing.T) {
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/video/1001", ContentType: "video"},
+		}
+		cache := map[string]string{
+			"https://www.tiktok.com/@user/video/1001": "photo", // cache says photo, but entry already set
+		}
+
+		unknown := applyContentTypesFromCache(entries, cache, ".", false)
+		if unknown != 0 {
+			t.Errorf("expected 0 unknown, got %d", unknown)
+		}
+		// Should keep the existing value, not overwrite
+		if entries[0].ContentType != "video" {
+			t.Errorf("expected 'video' (kept existing), got %q", entries[0].ContentType)
+		}
+	})
+}
+
+func TestPhotoArchive(t *testing.T) {
+	t.Run("getPhotoArchivePath collection mode", func(t *testing.T) {
+		path := getPhotoArchivePath("favorites", true)
+		expected := filepath.Join("favorites", "photo_archive.txt")
+		if path != expected {
+			t.Errorf("expected %q, got %q", expected, path)
+		}
+	})
+
+	t.Run("getPhotoArchivePath flat mode", func(t *testing.T) {
+		path := getPhotoArchivePath(".", false)
+		if path != "photo_archive.txt" {
+			t.Errorf("expected 'photo_archive.txt', got %q", path)
+		}
+	})
+
+	t.Run("appendToPhotoArchive creates and appends", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		archivePath := filepath.Join(tmpDir, "photo_archive.txt")
+
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/photo/1001"},
+			{Link: "https://www.tiktok.com/@user/photo/1002"},
+		}
+
+		err := appendToPhotoArchive(archivePath, entries)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Read and verify
+		archive, err := parseArchiveFile(archivePath)
+		if err != nil {
+			t.Fatalf("failed to parse archive: %v", err)
+		}
+		if !archive["1001"] || !archive["1002"] {
+			t.Errorf("expected both IDs in archive, got %v", archive)
+		}
+	})
+
+	t.Run("appendToPhotoArchive appends to existing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		archivePath := filepath.Join(tmpDir, "photo_archive.txt")
+
+		// Write initial entry
+		if err := os.WriteFile(archivePath, []byte("tiktok 1001\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		entries := []VideoEntry{
+			{Link: "https://www.tiktok.com/@user/photo/1002"},
+		}
+
+		err := appendToPhotoArchive(archivePath, entries)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		archive, err := parseArchiveFile(archivePath)
+		if err != nil {
+			t.Fatalf("failed to parse archive: %v", err)
+		}
+		if !archive["1001"] || !archive["1002"] {
+			t.Errorf("expected both IDs, got %v", archive)
+		}
+	})
+
+	t.Run("appendToPhotoArchive skips empty video IDs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		archivePath := filepath.Join(tmpDir, "photo_archive.txt")
+
+		entries := []VideoEntry{
+			{Link: "https://invalid-url-no-id"},
+		}
+
+		err := appendToPhotoArchive(archivePath, entries)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, _ := os.ReadFile(archivePath)
+		if len(strings.TrimSpace(string(data))) != 0 {
+			t.Errorf("expected empty archive, got %q", string(data))
 		}
 	})
 }

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -296,169 +296,130 @@ func (m *MockCommandRunner) Run(name string, args ...string) (CapturedOutput, er
 // TestRunYtdlpWithRunner tests the runYtdlp function with mocked command execution
 func TestRunYtdlpWithRunner(t *testing.T) {
 	tests := []struct {
-		name                 string
-		psPrefix             string
-		outputName           string
-		organizeByCollection bool
-		skipThumbnails       bool
-		disableResume        bool
-		cookieFile           string
-		cookieFromBrowser    string
-		shouldFail           bool
-		expectCmd            string
-		expectArgs           []string
+		name       string
+		psPrefix   string
+		outputName string
+		config     *Config
+		shouldFail bool
+		expectCmd  string
+		expectArgs []string
 	}{
 		{
-			name:                 "successful execution without powershell prefix",
-			psPrefix:             "",
-			outputName:           "test_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       false,
-			disableResume:        true,
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
+			name:       "successful execution without powershell prefix",
+			psPrefix:   "",
+			outputName: "test_videos.txt",
+			config:     &Config{DisableResume: true},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
 		},
 		{
-			name:                 "successful execution with powershell prefix",
-			psPrefix:             ".\\",
-			outputName:           "fav_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       false,
-			disableResume:        true,
-			shouldFail:           false,
-			expectCmd:            ".\\yt-dlp.exe",
-			expectArgs:           []string{"-a", "fav_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
+			name:       "successful execution with powershell prefix",
+			psPrefix:   ".\\",
+			outputName: "fav_videos.txt",
+			config:     &Config{DisableResume: true},
+			shouldFail: false,
+			expectCmd:  ".\\yt-dlp.exe",
+			expectArgs: []string{"-a", "fav_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
 		},
 		{
-			name:                 "command execution failure",
-			psPrefix:             "",
-			outputName:           "videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       false,
-			disableResume:        true,
-			shouldFail:           true,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
+			name:       "command execution failure",
+			psPrefix:   "",
+			outputName: "videos.txt",
+			config:     &Config{DisableResume: true},
+			shouldFail: true,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
 		},
 		{
-			name:                 "collection organized output goes to subdirectory",
-			psPrefix:             "",
-			outputName:           filepath.Join("favorites", "fav_videos.txt"),
-			organizeByCollection: true,
-			skipThumbnails:       false,
-			disableResume:        true,
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
+			name:       "collection organized output goes to subdirectory",
+			psPrefix:   "",
+			outputName: filepath.Join("favorites", "fav_videos.txt"),
+			config:     &Config{OrganizeByCollection: true, DisableResume: true},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
 		},
 		{
-			name:                 "skip thumbnails omits --write-thumbnail flag",
-			psPrefix:             "",
-			outputName:           "test_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       true,
-			disableResume:        true,
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json"},
+			name:       "skip thumbnails omits --write-thumbnail flag",
+			psPrefix:   "",
+			outputName: "test_videos.txt",
+			config:     &Config{SkipThumbnails: true, DisableResume: true},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json"},
 		},
 		{
-			name:                 "with cookie file",
-			psPrefix:             "",
-			outputName:           "test_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       false,
-			disableResume:        true,
-			cookieFile:           "cookies.txt",
-			cookieFromBrowser:    "",
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies", "cookies.txt"},
+			name:       "with cookie file",
+			psPrefix:   "",
+			outputName: "test_videos.txt",
+			config:     &Config{DisableResume: true, CookieFile: "cookies.txt"},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies", "cookies.txt"},
 		},
 		{
-			name:                 "with cookies from browser",
-			psPrefix:             "",
-			outputName:           "test_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       false,
-			disableResume:        true,
-			cookieFile:           "",
-			cookieFromBrowser:    "chrome",
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies-from-browser", "chrome"},
+			name:       "with cookies from browser",
+			psPrefix:   "",
+			outputName: "test_videos.txt",
+			config:     &Config{DisableResume: true, CookieFromBrowser: "chrome"},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies-from-browser", "chrome"},
 		},
 		{
-			name:                 "cookies with skip thumbnails",
-			psPrefix:             "",
-			outputName:           "test_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       true,
-			disableResume:        true,
-			cookieFile:           "cookies.txt",
-			cookieFromBrowser:    "",
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--cookies", "cookies.txt"},
+			name:       "cookies with skip thumbnails",
+			psPrefix:   "",
+			outputName: "test_videos.txt",
+			config:     &Config{SkipThumbnails: true, DisableResume: true, CookieFile: "cookies.txt"},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--cookies", "cookies.txt"},
 		},
 		{
-			name:                 "cookies with collection organization",
-			psPrefix:             "",
-			outputName:           filepath.Join("favorites", "fav_videos.txt"),
-			organizeByCollection: true,
-			skipThumbnails:       false,
-			disableResume:        true,
-			cookieFile:           "",
-			cookieFromBrowser:    "firefox",
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies-from-browser", "firefox"},
+			name:       "cookies with collection organization",
+			psPrefix:   "",
+			outputName: filepath.Join("favorites", "fav_videos.txt"),
+			config:     &Config{OrganizeByCollection: true, DisableResume: true, CookieFromBrowser: "firefox"},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies-from-browser", "firefox"},
 		},
 		{
-			name:                 "resume enabled with flat structure",
-			psPrefix:             "",
-			outputName:           "test_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       false,
-			disableResume:        false,
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
+			name:       "resume enabled with flat structure",
+			psPrefix:   "",
+			outputName: "test_videos.txt",
+			config:     &Config{},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
 		},
 		{
-			name:                 "resume enabled with collection organization",
-			psPrefix:             "",
-			outputName:           filepath.Join("favorites", "fav_videos.txt"),
-			organizeByCollection: true,
-			skipThumbnails:       false,
-			disableResume:        false,
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--download-archive", filepath.Join("favorites", "download_archive.txt"), "--no-overwrites", "--continue"},
+			name:       "resume enabled with collection organization",
+			psPrefix:   "",
+			outputName: filepath.Join("favorites", "fav_videos.txt"),
+			config:     &Config{OrganizeByCollection: true},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--download-archive", filepath.Join("favorites", "download_archive.txt"), "--no-overwrites", "--continue"},
 		},
 		{
-			name:                 "resume enabled with skip thumbnails",
-			psPrefix:             "",
-			outputName:           "test_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       true,
-			disableResume:        false,
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
+			name:       "resume enabled with skip thumbnails",
+			psPrefix:   "",
+			outputName: "test_videos.txt",
+			config:     &Config{SkipThumbnails: true},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
 		},
 		{
-			name:                 "resume enabled with cookies",
-			psPrefix:             "",
-			outputName:           "test_videos.txt",
-			organizeByCollection: false,
-			skipThumbnails:       false,
-			disableResume:        false,
-			cookieFile:           "cookies.txt",
-			shouldFail:           false,
-			expectCmd:            "yt-dlp.exe",
-			expectArgs:           []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies", "cookies.txt", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
+			name:       "resume enabled with cookies",
+			psPrefix:   "",
+			outputName: "test_videos.txt",
+			config:     &Config{CookieFile: "cookies.txt"},
+			shouldFail: false,
+			expectCmd:  "yt-dlp.exe",
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies", "cookies.txt", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
 		},
 	}
 
@@ -472,7 +433,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			}
 
 			// Capture output for verification
-			_, _ = runYtdlpWithRunner(mockRunner, tt.psPrefix, tt.outputName, tt.organizeByCollection, tt.skipThumbnails, tt.disableResume, tt.cookieFile, tt.cookieFromBrowser, testEntries)
+			_, _ = runYtdlpWithRunner(mockRunner, tt.psPrefix, tt.outputName, tt.config, testEntries)
 
 			// Verify command was called correctly
 			if len(mockRunner.Commands) != 1 {
@@ -3896,9 +3857,9 @@ func TestRunYtdlpWithSkipOptimization(t *testing.T) {
 
 	outputName := filepath.Join(tempDir, "fav_videos.txt")
 
-	// Call runYtdlpWithRunner with disableResume=false (optimization enabled)
+	// Call runYtdlpWithRunner with resume enabled (optimization enabled)
 	result, err := runYtdlpWithRunner(mockRunner, "", outputName,
-		true, false, false, "", "", entries)
+		&Config{OrganizeByCollection: true}, entries)
 
 	// Should not error
 	if err != nil {
@@ -3949,7 +3910,7 @@ func TestRunYtdlpWithDisableResume(t *testing.T) {
 
 	// Call with disableResume=true (optimization should be bypassed)
 	_, err := runYtdlpWithRunner(mockRunner, "", outputName,
-		true, false, true, "", "", entries)
+		&Config{OrganizeByCollection: true, DisableResume: true}, entries)
 
 	// Should not error
 	if err != nil {
@@ -3990,9 +3951,9 @@ func TestRunYtdlpPartialDownload(t *testing.T) {
 		{Link: "https://www.tiktok.com/@user/video/456"},
 	}
 
-	// Call with disableResume=false (optimization enabled but should still call yt-dlp)
+	// Call with resume enabled (optimization enabled but should still call yt-dlp)
 	_, err := runYtdlpWithRunner(mockRunner, "", outputName,
-		true, false, false, "", "", entries)
+		&Config{OrganizeByCollection: true}, entries)
 
 	// Should not error
 	if err != nil {
@@ -4712,7 +4673,7 @@ func (m *GalleryDlMockCommandRunner) Run(name string, args ...string) (CapturedO
 func TestRunGalleryDlWithRunner(t *testing.T) {
 	t.Run("empty entries returns immediately", func(t *testing.T) {
 		entries := []VideoEntry{}
-		result, err := runGalleryDl("", "test_dir", false, entries, "", "")
+		result, err := runGalleryDl("", "test_dir", &Config{}, entries)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -4738,7 +4699,7 @@ func TestRunGalleryDlWithRunner(t *testing.T) {
 
 		// Run with minimal settings - this will fail because gallery-dl.exe doesn't exist
 		// but we can verify the temp file creation and argument building
-		_, _ = runGalleryDl("", tmpDir, false, entries, "", "")
+		_, _ = runGalleryDl("", tmpDir, &Config{}, entries)
 
 		// Verify temp file was attempted (even if command failed)
 		// The function should have cleaned up the temp file on exit

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -1278,28 +1278,6 @@ func TestExtractVideoID(t *testing.T) {
 	}
 }
 
-// TestGetOutputFilename tests collection-specific filename generation
-func TestGetOutputFilename(t *testing.T) {
-	tests := []struct {
-		collection string
-		expected   string
-	}{
-		{"favorites", "fav_videos.txt"},
-		{"liked", "liked_videos.txt"},
-		{"other", "fav_videos.txt"},
-		{"", "fav_videos.txt"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.collection, func(t *testing.T) {
-			result := getOutputFilename(tt.collection)
-			if result != tt.expected {
-				t.Errorf("getOutputFilename(%q) = %q, want %q", tt.collection, result, tt.expected)
-			}
-		})
-	}
-}
-
 // TestParseInfoJSON tests parsing of yt-dlp info.json files
 func TestParseInfoJSON(t *testing.T) {
 	t.Run("valid info json", func(t *testing.T) {
@@ -3073,87 +3051,151 @@ func TestParseFlagsCookies(t *testing.T) {
 	})
 }
 
-// TestIsFileOlderThan30Days tests the age checking function
-func TestIsFileOlderThan30Days(t *testing.T) {
-	tmpDir := t.TempDir()
+// TestCompareVersions tests the version comparison function
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		local    string
+		remote   string
+		expected int
+	}{
+		{"equal versions", "2026.01.29", "2026.01.29", 0},
+		{"local older - year", "2025.01.29", "2026.01.29", -1},
+		{"local older - month", "2026.01.29", "2026.02.29", -1},
+		{"local older - day", "2026.01.28", "2026.01.29", -1},
+		{"local newer - year", "2026.01.29", "2025.01.29", 1},
+		{"local newer - month", "2026.02.29", "2026.01.29", 1},
+		{"local newer - day", "2026.01.30", "2026.01.29", 1},
+		{"empty local", "", "2026.01.29", -1},
+		{"empty remote", "2026.01.29", "", 1},
+		{"both empty", "", "", 0},
+	}
 
-	t.Run("file older than 30 days", func(t *testing.T) {
-		// Create a test file
-		testFile := filepath.Join(tmpDir, "old_file.txt")
-		if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
-			t.Fatalf("failed to create test file: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := compareVersions(tt.local, tt.remote)
+			if result != tt.expected {
+				t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.local, tt.remote, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetLatestYtdlpVersion tests fetching the latest version from GitHub
+func TestGetLatestYtdlpVersion(t *testing.T) {
+	t.Run("successful redirect parsing", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/yt-dlp/yt-dlp/releases/latest" {
+				w.Header().Set("Location", "https://github.com/yt-dlp/yt-dlp/releases/tag/2026.01.29")
+				w.WriteHeader(http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		client := server.Client()
+		// Override the URL for testing by using a custom transport
+		originalTransport := client.Transport
+		client.Transport = &redirectTestTransport{
+			server:   server,
+			original: originalTransport,
 		}
 
-		// Set modification time to 31 days ago
-		oldTime := time.Now().AddDate(0, 0, -31)
-		if err := os.Chtimes(testFile, oldTime, oldTime); err != nil {
-			t.Fatalf("failed to set file time: %v", err)
-		}
-
-		isOld, err := isFileOlderThan30Days(testFile)
+		version, err := getLatestYtdlpVersion(client)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if !isOld {
-			t.Error("expected file to be older than 30 days")
+		if version != "2026.01.29" {
+			t.Errorf("expected version 2026.01.29, got %s", version)
 		}
 	})
 
-	t.Run("file newer than 30 days", func(t *testing.T) {
-		// Create a test file
-		testFile := filepath.Join(tmpDir, "new_file.txt")
-		if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
-			t.Fatalf("failed to create test file: %v", err)
+	t.Run("network error", func(t *testing.T) {
+		// Create a client with a transport that always fails
+		client := &http.Client{
+			Transport: &errorTransport{err: fmt.Errorf("network unreachable")},
 		}
 
-		// Set modification time to 20 days ago
-		recentTime := time.Now().AddDate(0, 0, -20)
-		if err := os.Chtimes(testFile, recentTime, recentTime); err != nil {
-			t.Fatalf("failed to set file time: %v", err)
-		}
-
-		isOld, err := isFileOlderThan30Days(testFile)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if isOld {
-			t.Error("expected file to not be older than 30 days")
-		}
-	})
-
-	t.Run("file does not exist", func(t *testing.T) {
-		nonExistentFile := filepath.Join(tmpDir, "does_not_exist.txt")
-
-		_, err := isFileOlderThan30Days(nonExistentFile)
+		_, err := getLatestYtdlpVersion(client)
 		if err == nil {
-			t.Error("expected error for non-existent file, got nil")
+			t.Error("expected error for network failure, got nil")
 		}
 	})
 
-	t.Run("file exactly 30 days old", func(t *testing.T) {
-		testFile := filepath.Join(tmpDir, "exact_30_days.txt")
-		if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
-			t.Fatalf("failed to create test file: %v", err)
-		}
+	t.Run("unexpected status code", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK) // Should be 302, not 200
+		}))
+		defer server.Close()
 
-		// Set modification time to exactly 30 days ago
-		// Due to timing precision, this might not be exactly before the threshold
-		exactTime := time.Now().AddDate(0, 0, -30).Add(-time.Second)
-		if err := os.Chtimes(testFile, exactTime, exactTime); err != nil {
-			t.Fatalf("failed to set file time: %v", err)
-		}
+		client := server.Client()
+		client.Transport = &redirectTestTransport{server: server}
 
-		isOld, err := isFileOlderThan30Days(testFile)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+		_, err := getLatestYtdlpVersion(client)
+		if err == nil {
+			t.Error("expected error for unexpected status code, got nil")
 		}
-		// File just over 30 days old should be considered old
-		if !isOld {
-			t.Error("expected file over 30 days old to be considered old")
+	})
+
+	t.Run("missing location header", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusFound) // 302 but no Location header
+		}))
+		defer server.Close()
+
+		client := server.Client()
+		client.Transport = &redirectTestTransport{server: server}
+
+		_, err := getLatestYtdlpVersion(client)
+		if err == nil {
+			t.Error("expected error for missing location header, got nil")
+		}
+	})
+
+	t.Run("invalid redirect URL format", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Location", "https://github.com/yt-dlp/yt-dlp/releases/invalid")
+			w.WriteHeader(http.StatusFound)
+		}))
+		defer server.Close()
+
+		client := server.Client()
+		client.Transport = &redirectTestTransport{server: server}
+
+		_, err := getLatestYtdlpVersion(client)
+		if err == nil {
+			t.Error("expected error for invalid URL format, got nil")
 		}
 	})
 }
 
+// redirectTestTransport rewrites GitHub URLs to use the test server
+type redirectTestTransport struct {
+	server   *httptest.Server
+	original http.RoundTripper
+}
+
+func (t *redirectTestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rewrite the URL to point to our test server
+	if strings.Contains(req.URL.Host, "github.com") {
+		req.URL.Scheme = "http"
+		req.URL.Host = strings.TrimPrefix(t.server.URL, "http://")
+	}
+	if t.original != nil {
+		return t.original.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// errorTransport is an http.RoundTripper that always returns an error
+type errorTransport struct {
+	err error
+}
+
+func (t *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, t.err
+}
 // TestBackupYtdlp tests the backup functionality
 func TestBackupYtdlp(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -3303,72 +3345,6 @@ func TestDownloadLatestYtdlp(t *testing.T) {
 	if string(content) != "fake exe content" {
 		t.Errorf("downloaded content mismatch: got %q", content)
 	}
-}
-
-// TestGetOrDownloadYtdlpWithAgeCheck tests the complete flow including 30-day check
-func TestGetOrDownloadYtdlpWithAgeCheck(t *testing.T) {
-	tmpDir := t.TempDir()
-	oldCwd, _ := os.Getwd()
-	defer func() { _ = os.Chdir(oldCwd) }()
-
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatalf("failed to chdir to temp dir: %v", err)
-	}
-
-	exeName := "yt-dlp.exe"
-
-	t.Run("file newer than 30 days - no prompt", func(t *testing.T) {
-		// Create a file less than 30 days old
-		if err := os.WriteFile(exeName, []byte("current version"), 0644); err != nil {
-			t.Fatalf("failed to create test file: %v", err)
-		}
-		defer func() { _ = os.Remove(exeName) }()
-
-		// Set modification time to 15 days ago
-		recentTime := time.Now().AddDate(0, 0, -15)
-		if err := os.Chtimes(exeName, recentTime, recentTime); err != nil {
-			t.Fatalf("failed to set file time: %v", err)
-		}
-
-		// Should not attempt download
-		client := http.DefaultClient
-		if err := getOrDownloadYtdlp(client, exeName); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-
-		// File should still exist with same content
-		content, _ := os.ReadFile(exeName)
-		if string(content) != "current version" {
-			t.Error("file was modified when it shouldn't have been")
-		}
-	})
-
-	t.Run("file older than 30 days - requires manual test for prompt", func(t *testing.T) {
-		// Note: Full testing of the prompt interaction would require mocking stdin
-		// which is complex. This test just verifies the age detection works.
-		if err := os.WriteFile(exeName, []byte("old version"), 0644); err != nil {
-			t.Fatalf("failed to create test file: %v", err)
-		}
-		defer func() { _ = os.Remove(exeName) }()
-
-		// Set modification time to 31 days ago
-		oldTime := time.Now().AddDate(0, 0, -31)
-		if err := os.Chtimes(exeName, oldTime, oldTime); err != nil {
-			t.Fatalf("failed to set file time: %v", err)
-		}
-
-		// Verify file is detected as old
-		isOld, err := isFileOlderThan30Days(exeName)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !isOld {
-			t.Error("expected file to be detected as older than 30 days")
-		}
-
-		// Note: We can't fully test the prompt flow in automated tests
-		// because it requires stdin interaction. Manual testing required.
-	})
 }
 
 // TestParseProgressLine tests the progress line parser

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -193,7 +193,14 @@ func TestGetOrDownloadYtdlp(t *testing.T) {
 	}
 
 	client := http.DefaultClient // not actually used for this scenario
-	if err := getOrDownloadYtdlp(client, exeName); err != nil {
+	if err := getOrDownloadTool(client, &ToolConfig{
+		Name:            "yt-dlp",
+		ExeName:         "yt-dlp.exe",
+		GitHubRepo:      "yt-dlp/yt-dlp",
+		GetVersion:      getYtdlpVersion,
+		CompareVersions: compareVersions,
+		SelfUpdate:      updateYtdlp,
+	}); err != nil {
 		t.Errorf("expected nil error when file already exists, got %v", err)
 	}
 
@@ -236,7 +243,14 @@ func TestGetOrDownloadYtdlp(t *testing.T) {
 	}
 
 	// Now call getOrDownloadYtdlp again, which should attempt a download
-	if err := getOrDownloadYtdlp(customClient, exeName); err != nil {
+	if err := getOrDownloadTool(customClient, &ToolConfig{
+		Name:            "yt-dlp",
+		ExeName:         "yt-dlp.exe",
+		GitHubRepo:      "yt-dlp/yt-dlp",
+		GetVersion:      getYtdlpVersion,
+		CompareVersions: compareVersions,
+		SelfUpdate:      updateYtdlp,
+	}); err != nil {
 		t.Errorf("expected nil error on download scenario, got %v", err)
 	}
 
@@ -687,7 +701,14 @@ func TestGetOrDownloadYtdlpErrorScenarios(t *testing.T) {
 				},
 			}
 
-			err = getOrDownloadYtdlp(customClient, "yt-dlp.exe")
+			err = getOrDownloadTool(customClient, &ToolConfig{
+		Name:            "yt-dlp",
+		ExeName:         "yt-dlp.exe",
+		GitHubRepo:      "yt-dlp/yt-dlp",
+		GetVersion:      getYtdlpVersion,
+		CompareVersions: compareVersions,
+		SelfUpdate:      updateYtdlp,
+	})
 			if tt.expectError && err == nil {
 				t.Error("expected error but got none")
 			} else if !tt.expectError && err != nil {
@@ -3063,7 +3084,7 @@ func TestGetLatestYtdlpVersion(t *testing.T) {
 			original: originalTransport,
 		}
 
-		version, err := getLatestYtdlpVersion(client)
+		version, err := getLatestVersion(client, &ToolConfig{GitHubRepo: "yt-dlp/yt-dlp"})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -3078,7 +3099,7 @@ func TestGetLatestYtdlpVersion(t *testing.T) {
 			Transport: &errorTransport{err: fmt.Errorf("network unreachable")},
 		}
 
-		_, err := getLatestYtdlpVersion(client)
+		_, err := getLatestVersion(client, &ToolConfig{GitHubRepo: "yt-dlp/yt-dlp"})
 		if err == nil {
 			t.Error("expected error for network failure, got nil")
 		}
@@ -3093,7 +3114,7 @@ func TestGetLatestYtdlpVersion(t *testing.T) {
 		client := server.Client()
 		client.Transport = &redirectTestTransport{server: server}
 
-		_, err := getLatestYtdlpVersion(client)
+		_, err := getLatestVersion(client, &ToolConfig{GitHubRepo: "yt-dlp/yt-dlp"})
 		if err == nil {
 			t.Error("expected error for unexpected status code, got nil")
 		}
@@ -3108,7 +3129,7 @@ func TestGetLatestYtdlpVersion(t *testing.T) {
 		client := server.Client()
 		client.Transport = &redirectTestTransport{server: server}
 
-		_, err := getLatestYtdlpVersion(client)
+		_, err := getLatestVersion(client, &ToolConfig{GitHubRepo: "yt-dlp/yt-dlp"})
 		if err == nil {
 			t.Error("expected error for missing location header, got nil")
 		}
@@ -3124,7 +3145,7 @@ func TestGetLatestYtdlpVersion(t *testing.T) {
 		client := server.Client()
 		client.Transport = &redirectTestTransport{server: server}
 
-		_, err := getLatestYtdlpVersion(client)
+		_, err := getLatestVersion(client, &ToolConfig{GitHubRepo: "yt-dlp/yt-dlp"})
 		if err == nil {
 			t.Error("expected error for invalid URL format, got nil")
 		}
@@ -3177,7 +3198,7 @@ func TestBackupYtdlp(t *testing.T) {
 		}
 
 		// Backup
-		if err := backupYtdlp(exeName); err != nil {
+		if err := backupExe(exeName); err != nil {
 			t.Errorf("backup failed: %v", err)
 		}
 
@@ -3217,7 +3238,7 @@ func TestBackupYtdlp(t *testing.T) {
 		}
 
 		// Backup
-		if err := backupYtdlp(exeName); err != nil {
+		if err := backupExe(exeName); err != nil {
 			t.Errorf("backup failed: %v", err)
 		}
 
@@ -3240,7 +3261,7 @@ func TestBackupYtdlp(t *testing.T) {
 	t.Run("backup non-existent file", func(t *testing.T) {
 		exeName := "nonexistent.exe"
 
-		err := backupYtdlp(exeName)
+		err := backupExe(exeName)
 		if err == nil {
 			t.Error("expected error when backing up non-existent file")
 		}
@@ -3294,7 +3315,7 @@ func TestDownloadLatestYtdlp(t *testing.T) {
 	}
 
 	// Test download
-	if err := downloadLatestYtdlp(customClient, exeName); err != nil {
+	if err := downloadLatestRelease(customClient, &ToolConfig{Name: "yt-dlp", ExeName: exeName, GitHubRepo: "yt-dlp/yt-dlp"}); err != nil {
 		t.Errorf("download failed: %v", err)
 	}
 
@@ -4534,7 +4555,14 @@ func TestGetOrDownloadGalleryDl(t *testing.T) {
 
 		// Should return nil when file exists (won't check version since it's a dummy)
 		client := http.DefaultClient
-		err = getOrDownloadGalleryDl(client, exeName)
+		err = getOrDownloadTool(client, &ToolConfig{
+		Name:            "gallery-dl",
+		ExeName:         "gallery-dl.exe",
+		GitHubRepo:      "mikf/gallery-dl",
+		GetVersion:      getGalleryDlVersion,
+		CompareVersions: compareGalleryDlVersions,
+		StripVPrefix:    true,
+	})
 		if err != nil {
 			t.Errorf("expected nil error when file exists, got: %v", err)
 		}
@@ -4588,7 +4616,14 @@ func TestGetOrDownloadGalleryDl(t *testing.T) {
 			},
 		}
 
-		err = getOrDownloadGalleryDl(customClient, exeName)
+		err = getOrDownloadTool(customClient, &ToolConfig{
+		Name:            "gallery-dl",
+		ExeName:         "gallery-dl.exe",
+		GitHubRepo:      "mikf/gallery-dl",
+		GetVersion:      getGalleryDlVersion,
+		CompareVersions: compareGalleryDlVersions,
+		StripVPrefix:    true,
+	})
 		if err != nil {
 			t.Errorf("expected nil error on download, got: %v", err)
 		}
@@ -4611,8 +4646,6 @@ func TestGetOrDownloadGalleryDl(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatalf("failed to chdir: %v", err)
 		}
-
-		exeName := "gallery-dl.exe"
 
 		// Create a mock release JSON with wrong asset name
 		mockReleaseJSON := `{
@@ -4638,7 +4671,14 @@ func TestGetOrDownloadGalleryDl(t *testing.T) {
 			},
 		}
 
-		err = getOrDownloadGalleryDl(customClient, exeName)
+		err = getOrDownloadTool(customClient, &ToolConfig{
+		Name:            "gallery-dl",
+		ExeName:         "gallery-dl.exe",
+		GitHubRepo:      "mikf/gallery-dl",
+		GetVersion:      getGalleryDlVersion,
+		CompareVersions: compareGalleryDlVersions,
+		StripVPrefix:    true,
+	})
 		if err == nil {
 			t.Error("expected error when asset not found")
 		}
@@ -4760,7 +4800,7 @@ func TestGetLatestGalleryDlVersion(t *testing.T) {
 			original: client.Transport,
 		}
 
-		version, err := getLatestGalleryDlVersion(client)
+		version, err := getLatestVersion(client, &ToolConfig{GitHubRepo: "mikf/gallery-dl", StripVPrefix: true})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -4775,7 +4815,7 @@ func TestGetLatestGalleryDlVersion(t *testing.T) {
 			Transport: &errorTransport{err: fmt.Errorf("network unreachable")},
 		}
 
-		_, err := getLatestGalleryDlVersion(client)
+		_, err := getLatestVersion(client, &ToolConfig{GitHubRepo: "mikf/gallery-dl", StripVPrefix: true})
 		if err == nil {
 			t.Error("expected error for network failure, got nil")
 		}
@@ -4845,7 +4885,7 @@ func TestDownloadLatestGalleryDl(t *testing.T) {
 			},
 		}
 
-		err = downloadLatestGalleryDl(client, exeName)
+		err = downloadLatestRelease(client, &ToolConfig{Name: "gallery-dl", ExeName: exeName, GitHubRepo: "mikf/gallery-dl"})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -4883,7 +4923,7 @@ func TestDownloadLatestGalleryDl(t *testing.T) {
 			},
 		}
 
-		err = downloadLatestGalleryDl(client, "gallery-dl.exe")
+		err = downloadLatestRelease(client, &ToolConfig{Name: "gallery-dl", ExeName: "gallery-dl.exe", GitHubRepo: "mikf/gallery-dl"})
 		if err == nil {
 			t.Error("expected error for invalid JSON")
 		}
@@ -4911,7 +4951,7 @@ func TestBackupGalleryDl(t *testing.T) {
 			t.Fatalf("failed to create exe: %v", err)
 		}
 
-		err = backupGalleryDl(exeName)
+		err = backupExe(exeName)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -4944,7 +4984,7 @@ func TestBackupGalleryDl(t *testing.T) {
 			t.Fatalf("failed to chdir: %v", err)
 		}
 
-		err = backupGalleryDl("nonexistent.exe")
+		err = backupExe("nonexistent.exe")
 		if err == nil {
 			t.Error("expected error for non-existent file")
 		}

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -3623,6 +3623,63 @@ func TestProgressRenderer(t *testing.T) {
 	})
 }
 
+// TestRenderDetectionProgress tests the detection progress bar rendering
+func TestRenderDetectionProgress(t *testing.T) {
+	t.Run("disabled renderer produces no output", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderer := &ProgressRenderer{enabled: false, writer: &buf}
+
+		renderer.renderDetectionProgress(50, 100, 40, 8, 2)
+
+		if buf.Len() != 0 {
+			t.Errorf("expected no output when disabled, got %q", buf.String())
+		}
+	})
+
+	t.Run("enabled renderer writes expected format", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderer := &ProgressRenderer{enabled: true, writer: &buf}
+
+		renderer.renderDetectionProgress(50, 100, 40, 8, 2)
+
+		output := buf.String()
+		if !strings.Contains(output, "Detecting content types (50/100)") {
+			t.Errorf("expected progress count in output, got %q", output)
+		}
+		if !strings.Contains(output, "50.0%%") {
+			// Check for percentage (note: Sprintf uses %% for literal %)
+			if !strings.Contains(output, "50.0%") {
+				t.Errorf("expected percentage in output, got %q", output)
+			}
+		}
+		if !strings.Contains(output, "Videos: 40") {
+			t.Errorf("expected video count in output, got %q", output)
+		}
+		if !strings.Contains(output, "Photos: 8") {
+			t.Errorf("expected photo count in output, got %q", output)
+		}
+		if !strings.Contains(output, "Errors: 2") {
+			t.Errorf("expected error count in output, got %q", output)
+		}
+	})
+
+	t.Run("progress bar fills correctly at 100%", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderer := &ProgressRenderer{enabled: true, writer: &buf}
+
+		renderer.renderDetectionProgress(100, 100, 90, 10, 0)
+
+		output := buf.String()
+		if !strings.Contains(output, "100.0%") {
+			t.Errorf("expected 100%% in output, got %q", output)
+		}
+		// Should have full bar (20 filled blocks)
+		if !strings.Contains(output, strings.Repeat("█", 20)) {
+			t.Errorf("expected full progress bar, got %q", output)
+		}
+	})
+}
+
 // TestParseArchiveFile tests the parseArchiveFile function with various inputs
 func TestParseArchiveFile(t *testing.T) {
 	tests := []struct {
@@ -4964,7 +5021,7 @@ func TestDetectContentTypes(t *testing.T) {
 		client := &http.Client{}
 		cache := make(map[string]string)
 
-		result := detectContentTypes(entries, client, cache)
+		result := detectContentTypes(entries, client, cache, true)
 		if len(result) != 0 {
 			t.Errorf("expected empty map, got %d entries", len(result))
 		}
@@ -4978,7 +5035,7 @@ func TestDetectContentTypes(t *testing.T) {
 		client := &http.Client{}
 		cache := make(map[string]string)
 
-		result := detectContentTypes(entries, client, cache)
+		result := detectContentTypes(entries, client, cache, true)
 
 		// Should still process and return content types
 		if len(result) != 2 {
@@ -4997,7 +5054,7 @@ func TestDetectContentTypes(t *testing.T) {
 		}
 		cache := make(map[string]string)
 
-		result := detectContentTypes(entries, client, cache)
+		result := detectContentTypes(entries, client, cache, true)
 
 		if result[entries[0].Link] != "photo" {
 			t.Errorf("expected 'photo' content type, got %q", result[entries[0].Link])
@@ -5020,7 +5077,7 @@ func TestDetectContentTypes(t *testing.T) {
 			"https://www.tiktokv.com/share/video/222": "photo",
 		}
 
-		result := detectContentTypes(entries, client, cache)
+		result := detectContentTypes(entries, client, cache, true)
 
 		if result["https://www.tiktokv.com/share/video/111"] != "video" {
 			t.Errorf("expected 'video', got %q", result["https://www.tiktokv.com/share/video/111"])
@@ -5045,7 +5102,7 @@ func TestDetectContentTypes(t *testing.T) {
 			"https://www.tiktokv.com/share/video/111": "video",
 		}
 
-		result := detectContentTypes(entries, client, cache)
+		result := detectContentTypes(entries, client, cache, true)
 
 		if len(result) != 2 {
 			t.Errorf("expected 2 entries, got %d", len(result))

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -10,7 +10,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -702,13 +704,13 @@ func TestGetOrDownloadYtdlpErrorScenarios(t *testing.T) {
 			}
 
 			err = getOrDownloadTool(customClient, &ToolConfig{
-		Name:            "yt-dlp",
-		ExeName:         "yt-dlp.exe",
-		GitHubRepo:      "yt-dlp/yt-dlp",
-		GetVersion:      getYtdlpVersion,
-		CompareVersions: compareVersions,
-		SelfUpdate:      updateYtdlp,
-	})
+				Name:            "yt-dlp",
+				ExeName:         "yt-dlp.exe",
+				GitHubRepo:      "yt-dlp/yt-dlp",
+				GetVersion:      getYtdlpVersion,
+				CompareVersions: compareVersions,
+				SelfUpdate:      updateYtdlp,
+			})
 			if tt.expectError && err == nil {
 				t.Error("expected error but got none")
 			} else if !tt.expectError && err != nil {
@@ -4528,6 +4530,54 @@ func TestIsPhotoPost(t *testing.T) {
 			t.Errorf("expected finalURL to contain /photo/, got %q", finalURL)
 		}
 	})
+
+	t.Run("concurrent calls are race-free", func(t *testing.T) {
+		// Verify that isPhotoPost can be called concurrently on the same
+		// *http.Client without data races (requires -race flag to verify).
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Alternate between photo and video redirects based on a query param
+			if r.URL.Query().Get("type") == "photo" {
+				http.Redirect(w, r, "https://www.tiktok.com/@user/photo/"+r.URL.Query().Get("id"), http.StatusFound)
+			} else {
+				http.Redirect(w, r, "https://www.tiktok.com/@user/video/"+r.URL.Query().Get("id"), http.StatusFound)
+			}
+		}))
+		defer server.Close()
+
+		client := server.Client()
+
+		const goroutines = 50
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		errs := make(chan error, goroutines)
+
+		for i := 0; i < goroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				urlType := "video"
+				if idx%2 == 0 {
+					urlType = "photo"
+				}
+				url := server.URL + "?type=" + urlType + "&id=" + strconv.Itoa(idx)
+				isPhoto, _, err := isPhotoPost(url, client)
+				if err != nil {
+					errs <- fmt.Errorf("goroutine %d: unexpected error: %v", idx, err)
+					return
+				}
+				if urlType == "photo" && !isPhoto {
+					errs <- fmt.Errorf("goroutine %d: expected photo, got video", idx)
+				} else if urlType == "video" && isPhoto {
+					errs <- fmt.Errorf("goroutine %d: expected video, got photo", idx)
+				}
+			}(i)
+		}
+
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Error(err)
+		}
+	})
 }
 
 // TestGetOrDownloadGalleryDl tests the gallery-dl download function
@@ -4556,13 +4606,13 @@ func TestGetOrDownloadGalleryDl(t *testing.T) {
 		// Should return nil when file exists (won't check version since it's a dummy)
 		client := http.DefaultClient
 		err = getOrDownloadTool(client, &ToolConfig{
-		Name:            "gallery-dl",
-		ExeName:         "gallery-dl.exe",
-		GitHubRepo:      "mikf/gallery-dl",
-		GetVersion:      getGalleryDlVersion,
-		CompareVersions: compareGalleryDlVersions,
-		StripVPrefix:    true,
-	})
+			Name:            "gallery-dl",
+			ExeName:         "gallery-dl.exe",
+			GitHubRepo:      "mikf/gallery-dl",
+			GetVersion:      getGalleryDlVersion,
+			CompareVersions: compareGalleryDlVersions,
+			StripVPrefix:    true,
+		})
 		if err != nil {
 			t.Errorf("expected nil error when file exists, got: %v", err)
 		}
@@ -4617,13 +4667,13 @@ func TestGetOrDownloadGalleryDl(t *testing.T) {
 		}
 
 		err = getOrDownloadTool(customClient, &ToolConfig{
-		Name:            "gallery-dl",
-		ExeName:         "gallery-dl.exe",
-		GitHubRepo:      "mikf/gallery-dl",
-		GetVersion:      getGalleryDlVersion,
-		CompareVersions: compareGalleryDlVersions,
-		StripVPrefix:    true,
-	})
+			Name:            "gallery-dl",
+			ExeName:         "gallery-dl.exe",
+			GitHubRepo:      "mikf/gallery-dl",
+			GetVersion:      getGalleryDlVersion,
+			CompareVersions: compareGalleryDlVersions,
+			StripVPrefix:    true,
+		})
 		if err != nil {
 			t.Errorf("expected nil error on download, got: %v", err)
 		}
@@ -4672,13 +4722,13 @@ func TestGetOrDownloadGalleryDl(t *testing.T) {
 		}
 
 		err = getOrDownloadTool(customClient, &ToolConfig{
-		Name:            "gallery-dl",
-		ExeName:         "gallery-dl.exe",
-		GitHubRepo:      "mikf/gallery-dl",
-		GetVersion:      getGalleryDlVersion,
-		CompareVersions: compareGalleryDlVersions,
-		StripVPrefix:    true,
-	})
+			Name:            "gallery-dl",
+			ExeName:         "gallery-dl.exe",
+			GitHubRepo:      "mikf/gallery-dl",
+			GetVersion:      getGalleryDlVersion,
+			CompareVersions: compareGalleryDlVersions,
+			StripVPrefix:    true,
+		})
 		if err == nil {
 			t.Error("expected error when asset not found")
 		}
@@ -5004,28 +5054,13 @@ func TestDetectContentTypes(t *testing.T) {
 		}
 	})
 
-	t.Run("entries already typed", func(t *testing.T) {
-		entries := []VideoEntry{
-			{Link: "https://www.tiktok.com/@user/photo/123", ContentType: "photo"},
-			{Link: "https://www.tiktok.com/@user/video/456", ContentType: "video"},
-		}
-		client := &http.Client{}
-		cache := make(map[string]string)
-
-		result := detectContentTypes(entries, client, cache, true)
-
-		// Should still process and return content types
-		if len(result) != 2 {
-			t.Errorf("expected 2 entries, got %d", len(result))
-		}
-	})
-
-	t.Run("URL with /photo/ detected without network", func(t *testing.T) {
+	t.Run("photo URL in path detected without network", func(t *testing.T) {
+		// isPhotoPost returns true immediately for URLs containing /photo/ —
+		// no HTTP request needed. Only /photo/ URLs get the early return;
+		// /video/ URLs still require a network call to follow redirects.
 		entries := []VideoEntry{
 			{Link: "https://www.tiktok.com/@user/photo/123"},
 		}
-
-		// Use a client that fails on any request - shouldn't be called for /photo/ URLs
 		client := &http.Client{
 			Transport: &errorTransport{err: fmt.Errorf("should not be called")},
 		}
@@ -5033,8 +5068,11 @@ func TestDetectContentTypes(t *testing.T) {
 
 		result := detectContentTypes(entries, client, cache, true)
 
-		if result[entries[0].Link] != "photo" {
-			t.Errorf("expected 'photo' content type, got %q", result[entries[0].Link])
+		if len(result) != 1 {
+			t.Errorf("expected 1 entry, got %d", len(result))
+		}
+		if result["https://www.tiktok.com/@user/photo/123"] != "photo" {
+			t.Errorf("expected 'photo', got %q", result["https://www.tiktok.com/@user/photo/123"])
 		}
 	})
 
@@ -5061,6 +5099,46 @@ func TestDetectContentTypes(t *testing.T) {
 		}
 		if result["https://www.tiktokv.com/share/video/222"] != "photo" {
 			t.Errorf("expected 'photo', got %q", result["https://www.tiktokv.com/share/video/222"])
+		}
+	})
+
+	t.Run("redirect-based detection through worker pool", func(t *testing.T) {
+		// Integration test: exercises the full worker pool with actual HTTP redirects.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/short/1":
+				http.Redirect(w, r, "https://www.tiktok.com/@user/photo/1001", http.StatusFound)
+			case "/short/2":
+				http.Redirect(w, r, "https://www.tiktok.com/@user/video/1002", http.StatusFound)
+			case "/short/3":
+				http.Redirect(w, r, "https://www.tiktok.com/@user/photo/1003", http.StatusFound)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		entries := []VideoEntry{
+			{Link: server.URL + "/short/1"},
+			{Link: server.URL + "/short/2"},
+			{Link: server.URL + "/short/3"},
+		}
+		client := server.Client()
+		cache := make(map[string]string)
+
+		result := detectContentTypes(entries, client, cache, true)
+
+		if len(result) != 3 {
+			t.Fatalf("expected 3 entries, got %d", len(result))
+		}
+		if result[entries[0].Link] != "photo" {
+			t.Errorf("entry 0: expected 'photo', got %q", result[entries[0].Link])
+		}
+		if result[entries[1].Link] != "video" {
+			t.Errorf("entry 1: expected 'video', got %q", result[entries[1].Link])
+		}
+		if result[entries[2].Link] != "photo" {
+			t.Errorf("entry 2: expected 'photo', got %q", result[entries[2].Link])
 		}
 	})
 

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"flag"
@@ -325,7 +326,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{DisableResume: true},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg"},
 		},
 		{
 			name:       "successful execution with powershell prefix",
@@ -334,7 +335,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{DisableResume: true},
 			shouldFail: false,
 			expectCmd:  ".\\yt-dlp.exe",
-			expectArgs: []string{"-a", "fav_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
+			expectArgs: []string{"-a", "fav_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg"},
 		},
 		{
 			name:       "command execution failure",
@@ -343,7 +344,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{DisableResume: true},
 			shouldFail: true,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
+			expectArgs: []string{"-a", "videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg"},
 		},
 		{
 			name:       "collection organized output goes to subdirectory",
@@ -352,7 +353,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{OrganizeByCollection: true, DisableResume: true},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg"},
+			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg"},
 		},
 		{
 			name:       "skip thumbnails omits --write-thumbnail flag",
@@ -361,7 +362,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{SkipThumbnails: true, DisableResume: true},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json"},
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36"},
 		},
 		{
 			name:       "with cookie file",
@@ -370,7 +371,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{DisableResume: true, CookieFile: "cookies.txt"},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies", "cookies.txt"},
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies", "cookies.txt"},
 		},
 		{
 			name:       "with cookies from browser",
@@ -379,7 +380,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{DisableResume: true, CookieFromBrowser: "chrome"},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies-from-browser", "chrome"},
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies-from-browser", "chrome"},
 		},
 		{
 			name:       "cookies with skip thumbnails",
@@ -388,7 +389,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{SkipThumbnails: true, DisableResume: true, CookieFile: "cookies.txt"},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--cookies", "cookies.txt"},
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--cookies", "cookies.txt"},
 		},
 		{
 			name:       "cookies with collection organization",
@@ -397,7 +398,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{OrganizeByCollection: true, DisableResume: true, CookieFromBrowser: "firefox"},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies-from-browser", "firefox"},
+			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies-from-browser", "firefox"},
 		},
 		{
 			name:       "resume enabled with flat structure",
@@ -406,7 +407,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
 		},
 		{
 			name:       "resume enabled with collection organization",
@@ -415,7 +416,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{OrganizeByCollection: true},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--download-archive", filepath.Join("favorites", "download_archive.txt"), "--no-overwrites", "--continue"},
+			expectArgs: []string{"-a", filepath.Join("favorites", "fav_videos.txt"), "--output", filepath.Join("favorites", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s"), "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg", "--download-archive", filepath.Join("favorites", "download_archive.txt"), "--no-overwrites", "--continue"},
 		},
 		{
 			name:       "resume enabled with skip thumbnails",
@@ -424,7 +425,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{SkipThumbnails: true},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
 		},
 		{
 			name:       "resume enabled with cookies",
@@ -433,7 +434,7 @@ func TestRunYtdlpWithRunner(t *testing.T) {
 			config:     &Config{CookieFile: "cookies.txt"},
 			shouldFail: false,
 			expectCmd:  "yt-dlp.exe",
-			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies", "cookies.txt", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
+			expectArgs: []string{"-a", "test_videos.txt", "--output", "%(upload_date)s_%(id)s_%(title).50B.%(ext)s", "--write-info-json", "--add-headers", "User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7671.0 Safari/537.36", "--write-thumbnail", "--convert-thumbnails", "jpg", "--cookies", "cookies.txt", "--download-archive", "download_archive.txt", "--no-overwrites", "--continue"},
 		},
 	}
 
@@ -3178,6 +3179,7 @@ type errorTransport struct {
 func (t *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return nil, t.err
 }
+
 // TestBackupYtdlp tests the backup functionality
 func TestBackupYtdlp(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -4203,6 +4205,36 @@ func TestParseGalleryDlOutput(t *testing.T) {
 				t.Errorf("expected %d failures, got %d", tt.expectedFails, len(failures))
 			}
 		})
+	}
+}
+
+// TestParseGalleryDlOutputDedup tests that duplicate error lines for the same video ID are counted only once
+func TestParseGalleryDlOutputDedup(t *testing.T) {
+	entries := []VideoEntry{
+		{Link: "https://www.tiktok.com/@user/photo/7597601281703693623"},
+		{Link: "https://www.tiktok.com/@user/photo/7597601281703693624"},
+	}
+
+	lines := []string{
+		"ERROR: Unable to download 7597601281703693623: Not available",
+		"[error] 7597601281703693623: failed to extract images",
+		"ERROR: Unable to download 7597601281703693624: connection refused",
+	}
+
+	_, failures := parseGalleryDlOutput(lines, entries)
+
+	// 7597601281703693623 has two error lines but should only appear once in failures
+	if len(failures) != 2 {
+		t.Errorf("expected 2 unique failures, got %d", len(failures))
+	}
+
+	// Verify the correct IDs are present
+	ids := make(map[string]bool)
+	for _, f := range failures {
+		ids[f.VideoID] = true
+	}
+	if !ids["7597601281703693623"] || !ids["7597601281703693624"] {
+		t.Errorf("expected both video IDs in failures, got %v", ids)
 	}
 }
 
@@ -5281,4 +5313,100 @@ func TestPhotoArchive(t *testing.T) {
 			t.Errorf("expected empty archive, got %q", string(data))
 		}
 	})
+}
+
+// TestScanLinesAndCR tests the custom scanner split function that handles \r, \n, and \r\n
+func TestScanLinesAndCR(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "newline only",
+			input:    "line1\nline2\nline3",
+			expected: []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "carriage return only",
+			input:    "progress1\rprogress2\rprogress3",
+			expected: []string{"progress1", "progress2", "progress3"},
+		},
+		{
+			name:     "crlf",
+			input:    "line1\r\nline2\r\nline3",
+			expected: []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "mixed delimiters",
+			input:    "[download] Downloading item 1 of 5\n[download]  50.2% of ~10MiB\r[download] 100% of ~10MiB\r\n[download] Downloading item 2 of 5",
+			expected: []string{"[download] Downloading item 1 of 5", "[download]  50.2% of ~10MiB", "[download] 100% of ~10MiB", "[download] Downloading item 2 of 5"},
+		},
+		{
+			name:     "empty lines",
+			input:    "a\n\nb",
+			expected: []string{"a", "", "b"},
+		},
+		{
+			name:     "single line no delimiter",
+			input:    "hello",
+			expected: []string{"hello"},
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := bufio.NewScanner(strings.NewReader(tt.input))
+			scanner.Split(scanLinesAndCR)
+
+			var got []string
+			for scanner.Scan() {
+				got = append(got, scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				t.Fatalf("scanner error: %v", err)
+			}
+
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %d tokens, got %d: %v", len(tt.expected), len(got), got)
+			}
+			for i, want := range tt.expected {
+				if got[i] != want {
+					t.Errorf("token[%d]: expected %q, got %q", i, want, got[i])
+				}
+			}
+		})
+	}
+}
+
+// TestIsVerboseLinePercentage tests that intermediate percentage lines are filtered as verbose
+func TestIsVerboseLinePercentage(t *testing.T) {
+	// These should be considered verbose (suppressed)
+	verbose := []string{
+		"[download]  50.2% of ~10.50MiB at 2.50MiB/s ETA 00:03",
+		"[download] 100% of 5.00MiB",
+		"[download]   3.5% of ~22.00MiB at  1.20MiB/s ETA 00:18",
+	}
+	for _, line := range verbose {
+		if !isVerboseLine(line) {
+			t.Errorf("expected %q to be verbose", line)
+		}
+	}
+
+	// These should NOT be verbose
+	notVerbose := []string{
+		"ERROR: [TikTok] 12345: Video not available",
+		"WARNING: some warning",
+		"[download] Downloading item 1 of 10",
+	}
+	for _, line := range notVerbose {
+		if isVerboseLine(line) {
+			t.Errorf("expected %q to NOT be verbose", line)
+		}
+	}
 }

--- a/generate_tiktok_links_test.go
+++ b/generate_tiktok_links_test.go
@@ -4070,3 +4070,318 @@ func TestOutputProcessing(t *testing.T) {
 		t.Error("Output should contain carriage returns for progress bar updates")
 	}
 }
+
+// ============================================================================
+// Photo Support Tests
+// ============================================================================
+
+// TestExtractVideoIDWithPhotoURL tests that extractVideoID works with photo URLs
+func TestExtractVideoIDWithPhotoURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "standard video URL",
+			url:      "https://www.tiktok.com/@user/video/7600559584901647646",
+			expected: "7600559584901647646",
+		},
+		{
+			name:     "photo URL",
+			url:      "https://www.tiktok.com/@user/photo/7597601281703693623",
+			expected: "7597601281703693623",
+		},
+		{
+			name:     "tiktokv share URL",
+			url:      "https://www.tiktokv.com/share/video/7597601281703693623/",
+			expected: "7597601281703693623",
+		},
+		{
+			name:     "mobile URL",
+			url:      "https://m.tiktok.com/v/7600559584901647646.html",
+			expected: "7600559584901647646",
+		},
+		{
+			name:     "invalid URL",
+			url:      "https://www.tiktok.com/@user",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractVideoID(tt.url)
+			if result != tt.expected {
+				t.Errorf("extractVideoID(%q) = %q, want %q", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestSeparateEntriesByContentType tests that entries are correctly separated
+func TestSeparateEntriesByContentType(t *testing.T) {
+	entries := []VideoEntry{
+		{Link: "https://www.tiktok.com/@user/video/1", ContentType: "video"},
+		{Link: "https://www.tiktok.com/@user/photo/2", ContentType: "photo"},
+		{Link: "https://www.tiktok.com/@user/video/3", ContentType: "video"},
+		{Link: "https://www.tiktok.com/@user/photo/4", ContentType: "photo"},
+		{Link: "https://www.tiktok.com/@user/video/5", ContentType: ""}, // empty defaults to video
+	}
+
+	videos, photos := separateEntriesByContentType(entries)
+
+	if len(videos) != 3 {
+		t.Errorf("expected 3 videos, got %d", len(videos))
+	}
+	if len(photos) != 2 {
+		t.Errorf("expected 2 photos, got %d", len(photos))
+	}
+
+	// Verify all photos have ContentType "photo"
+	for _, p := range photos {
+		if p.ContentType != "photo" {
+			t.Errorf("photo entry has wrong ContentType: %s", p.ContentType)
+		}
+	}
+}
+
+// TestGetVideoAndPhotoOutputFilenames tests the separate filename functions
+func TestGetVideoAndPhotoOutputFilenames(t *testing.T) {
+	// Test video filenames
+	if got := getVideoOutputFilename("favorites"); got != "fav_videos.txt" {
+		t.Errorf("getVideoOutputFilename(favorites) = %q, want %q", got, "fav_videos.txt")
+	}
+	if got := getVideoOutputFilename("liked"); got != "liked_videos.txt" {
+		t.Errorf("getVideoOutputFilename(liked) = %q, want %q", got, "liked_videos.txt")
+	}
+
+	// Test photo filenames
+	if got := getPhotoOutputFilename("favorites"); got != "fav_photos.txt" {
+		t.Errorf("getPhotoOutputFilename(favorites) = %q, want %q", got, "fav_photos.txt")
+	}
+	if got := getPhotoOutputFilename("liked"); got != "liked_photos.txt" {
+		t.Errorf("getPhotoOutputFilename(liked) = %q, want %q", got, "liked_photos.txt")
+	}
+}
+
+// TestCompareGalleryDlVersions tests version comparison for gallery-dl
+func TestCompareGalleryDlVersions(t *testing.T) {
+	tests := []struct {
+		local    string
+		remote   string
+		expected int
+	}{
+		{"1.28.0", "1.28.0", 0},  // equal
+		{"1.28.0", "1.28.1", -1}, // local older
+		{"1.28.1", "1.28.0", 1},  // local newer
+		{"1.27.5", "1.28.0", -1}, // local older (minor version)
+		{"2.0.0", "1.99.99", 1},  // local newer (major version)
+		{"1.28", "1.28.0", -1},   // local shorter
+		{"1.28.0", "1.28", 1},    // local longer
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_vs_%s", tt.local, tt.remote), func(t *testing.T) {
+			result := compareGalleryDlVersions(tt.local, tt.remote)
+			if result != tt.expected {
+				t.Errorf("compareGalleryDlVersions(%q, %q) = %d, want %d",
+					tt.local, tt.remote, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestParseGalleryDlOutput tests parsing of gallery-dl output for success/failure
+func TestParseGalleryDlOutput(t *testing.T) {
+	entries := []VideoEntry{
+		{Link: "https://www.tiktok.com/@user/photo/7597601281703693623", VideoID: "7597601281703693623"},
+		{Link: "https://www.tiktok.com/@user/photo/7597601281703693624", VideoID: "7597601281703693624"},
+	}
+
+	tests := []struct {
+		name            string
+		lines           []string
+		expectedSuccess int
+		expectedFails   int
+	}{
+		{
+			name: "all success",
+			lines: []string{
+				"#1 https://www.tiktok.com/@user/photo/7597601281703693623",
+				"#2 https://www.tiktok.com/@user/photo/7597601281703693624",
+			},
+			expectedSuccess: 2,
+			expectedFails:   0,
+		},
+		{
+			name: "one failure",
+			lines: []string{
+				"#1 https://www.tiktok.com/@user/photo/7597601281703693623",
+				"ERROR: Unable to download 7597601281703693624: Not available",
+			},
+			expectedSuccess: 1,
+			expectedFails:   1,
+		},
+		{
+			name: "all failures",
+			lines: []string{
+				"[error] 7597601281703693623: failed to extract images",
+				"ERROR: 7597601281703693624: connection refused",
+			},
+			expectedSuccess: 0,
+			expectedFails:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			success, failures := parseGalleryDlOutput(tt.lines, entries)
+			if success != tt.expectedSuccess {
+				t.Errorf("expected %d successes, got %d", tt.expectedSuccess, success)
+			}
+			if len(failures) != tt.expectedFails {
+				t.Errorf("expected %d failures, got %d", tt.expectedFails, len(failures))
+			}
+		})
+	}
+}
+
+// TestCalculateSessionTotalsWithPhotos tests that session totals include photo stats
+func TestCalculateSessionTotalsWithPhotos(t *testing.T) {
+	collections := []CollectionResult{
+		{
+			Name:        "favorites-videos",
+			ContentType: "video",
+			Attempted:   100,
+			Success:     90,
+			Failed:      10,
+			Skipped:     5,
+		},
+		{
+			Name:        "favorites-photos",
+			ContentType: "photo",
+			Attempted:   20,
+			Success:     18,
+			Failed:      2,
+			Skipped:     0,
+		},
+		{
+			Name:        "liked-videos",
+			ContentType: "video",
+			Attempted:   50,
+			Success:     45,
+			Failed:      5,
+			Skipped:     2,
+		},
+	}
+
+	attempted, success, failed, skipped, photosAttempted, photosSuccess, photosFailed :=
+		calculateSessionTotals(collections)
+
+	if attempted != 170 {
+		t.Errorf("expected total attempted 170, got %d", attempted)
+	}
+	if success != 153 {
+		t.Errorf("expected total success 153, got %d", success)
+	}
+	if failed != 17 {
+		t.Errorf("expected total failed 17, got %d", failed)
+	}
+	if skipped != 7 {
+		t.Errorf("expected total skipped 7, got %d", skipped)
+	}
+	if photosAttempted != 20 {
+		t.Errorf("expected photos attempted 20, got %d", photosAttempted)
+	}
+	if photosSuccess != 18 {
+		t.Errorf("expected photos success 18, got %d", photosSuccess)
+	}
+	if photosFailed != 2 {
+		t.Errorf("expected photos failed 2, got %d", photosFailed)
+	}
+}
+
+// TestCollectionResultContentType tests that ContentType is properly tracked
+func TestCollectionResultContentType(t *testing.T) {
+	result := &CollectionResult{
+		Name:        "favorites",
+		ContentType: "photo",
+		Attempted:   10,
+		Success:     8,
+		Failed:      2,
+	}
+
+	if result.ContentType != "photo" {
+		t.Errorf("expected ContentType 'photo', got %q", result.ContentType)
+	}
+}
+
+// TestVideoEntryPhotoFields tests that VideoEntry has photo-specific fields
+func TestVideoEntryPhotoFields(t *testing.T) {
+	entry := VideoEntry{
+		Link:        "https://www.tiktok.com/@user/photo/123",
+		ContentType: "photo",
+		ImageCount:  5,
+		ImageFiles:  []string{"img1.jpg", "img2.jpg", "img3.jpg", "img4.jpg", "img5.jpg"},
+		AudioFile:   "audio.m4a",
+	}
+
+	if entry.ContentType != "photo" {
+		t.Errorf("expected ContentType 'photo', got %q", entry.ContentType)
+	}
+	if entry.ImageCount != 5 {
+		t.Errorf("expected ImageCount 5, got %d", entry.ImageCount)
+	}
+	if len(entry.ImageFiles) != 5 {
+		t.Errorf("expected 5 image files, got %d", len(entry.ImageFiles))
+	}
+	if entry.AudioFile != "audio.m4a" {
+		t.Errorf("expected AudioFile 'audio.m4a', got %q", entry.AudioFile)
+	}
+}
+
+// TestWriteFavoriteVideosToFileWithPhotos tests that photos are written to separate files
+func TestWriteFavoriteVideosToFileWithPhotos(t *testing.T) {
+	// Create temp directory
+	tempDir, err := os.MkdirTemp("", "photo_test_*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Create entries with mixed content types
+	entries := []VideoEntry{
+		{Link: "https://www.tiktok.com/@user/video/1", ContentType: "video", Collection: "favorites"},
+		{Link: "https://www.tiktok.com/@user/photo/2", ContentType: "photo", Collection: "favorites"},
+		{Link: "https://www.tiktok.com/@user/video/3", ContentType: "video", Collection: "favorites"},
+	}
+
+	// Test flat structure
+	outputName := filepath.Join(tempDir, "fav_videos.txt")
+	err = writeFavoriteVideosToFile(entries, outputName, false)
+	if err != nil {
+		t.Fatalf("writeFavoriteVideosToFile failed: %v", err)
+	}
+
+	// Check video file
+	videoContent, err := os.ReadFile(outputName)
+	if err != nil {
+		t.Fatalf("failed to read video file: %v", err)
+	}
+	videoLines := strings.Split(strings.TrimSpace(string(videoContent)), "\n")
+	if len(videoLines) != 2 {
+		t.Errorf("expected 2 video URLs, got %d", len(videoLines))
+	}
+
+	// Check photo file
+	photoFile := filepath.Join(tempDir, "fav_photos.txt")
+	photoContent, err := os.ReadFile(photoFile)
+	if err != nil {
+		t.Fatalf("failed to read photo file: %v", err)
+	}
+	photoLines := strings.Split(strings.TrimSpace(string(photoContent)), "\n")
+	if len(photoLines) != 1 {
+		t.Errorf("expected 1 photo URL, got %d", len(photoLines))
+	}
+}


### PR DESCRIPTION
 ## Summary

 - Photo/slideshow support with gallery-dl integration (from rc1)
 - Replaced slow HTTP-based content type detection with yt-dlp-first/gallery-dl-fallback approach — eliminates the
 2+ day startup delay on large collections
 - Fixed progress bar freeze caused by yt-dlp's `\r` output overflowing the scanner buffer
 - Fixed photo download success count always reporting 0
 - Custom Chrome User-Agent header for yt-dlp to reduce TikTok blocks

 ## What's Changed Since v2.0.0

 ### New Features
 - **Photo/slideshow support** — TikTok photo carousels are now downloaded via gallery-dl (auto-downloaded from
 GitHub). Unified index.html displays both videos and photos
 - **Content type caching** — `content_types_cache.json` persists URL-to-type mappings across runs, so subsequent
 runs skip detection entirely
 - **Progress bar for content detection** — ANSI progress bar shown during the content type resolution phase

 ### Performance
 - **yt-dlp first, gallery-dl fallback** — replaces per-URL HTTP detection (which TikTok rate-limits aggressively)
 with a try-then-fallback approach. Reduces startup from hours/days to minutes
 - **Concurrent content type detection** — 10-worker pool for parallel cache/disk inference
 - **Pre-compiled regex patterns** — moved to package-level `var` block

 ### Bug Fixes
 - **Progress bar freeze** — yt-dlp's bare `\r` percentage updates accumulated into a single 64KB+ token, silently
 killing the `bufio.Scanner`. New `scanLinesAndCR` split function handles `\r`, `\n`, and `\r\n`
 - **Photo success count always 0** — `parseGalleryDlOutput` relied on matching gallery-dl's `#N` output format
 which didn't work. Switched to subtraction method (total - failures). Also fixed duplicate error counting and
 archive update guard
 - **yt-dlp update check on Windows** (#27) — uses `yt-dlp --version` instead of file modification time
 - **Custom User-Agent header** — sends Chrome UA instead of yt-dlp default to reduce TikTok IP blocks

 ### Refactoring
 - Unified `ToolConfig` struct for yt-dlp and gallery-dl management
 - Extracted `scanPhotoFiles` helper, common progress bar helpers
 - Replaced individual function params with `*Config` struct
 - Removed dead code (`isFileOlderThan30Days`, `getOutputFilename`)

 🤖 Generated with [Claude Code](https://claude.com/claude-code)