### PR TITLE
build: bump Go to 1.26.6 and update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/check-every-devpush-and-mainPR.yml
+++ b/.github/workflows/check-every-devpush-and-mainPR.yml
@@ -25,17 +25,17 @@ jobs:
     steps:
       # 1. Check out the repository code
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       # 2. Set up Go environment
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7.0.0
         with:
-          go-version: '1.25.1'  # or whichever version of Go you prefer
+          go-version: '1.26.6'  # or whichever version of Go you prefer
 
       # 3. (Optional) Cache Go modules for faster builds
       - name: Cache modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ~/go/pkg/mod
@@ -49,7 +49,7 @@ jobs:
 
       # 5. Run lint checks (golangci-lint-action)
       - name: Run lint checks
-        uses: golangci/golangci-lint-action@v8.0.0
+        uses: golangci/golangci-lint-action@v9.3.0
 
       # 7. Run Go tests
       - name: Run Go tests

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7.0.0
         with:
-          go-version: '1.25.1'
+          go-version: '1.26.6'
 
       - name: Get version from Git
         id: get_version
@@ -46,7 +46,7 @@ jobs:
 
       # 7. Create a new draft GitHub release with this version
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for considering contributing to this project! This document outlines t
 ## Development Setup
 
 ### Prerequisites
-- **Go 1.25.1 or later** (required for building)
+- **Go 1.26.6 or later** (required for building)
 - Git for version control
 - A Windows machine for testing (or WSL/cross-compilation for non-Windows development)
 
@@ -180,7 +180,7 @@ This project uses **semantic versioning** (e.g., `v1.2.3`):
 - Pull requests targeting `main`
 
 **Actions**:
-- Sets up Go 1.25.1
+- Sets up Go 1.26.6
 - Downloads dependencies
 - Runs linting (`golangci-lint`)
 - Runs full test suite

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Backup all those tiktok videos you've favorited & liked, just like the digital h
 Binary is not signed (didn't have time+budget), you WILL have to tell Windows you trust it.
 
 ![Release](https://github.com/ozskywalker/tiktok-favvideo-downloader/actions/workflows/release-on-tag.yml/badge.svg)
-[![Go Version](https://img.shields.io/badge/Go-1.25.1-blue.svg)](https://golang.org/doc/devel/release.html)
+[![Go Version](https://img.shields.io/badge/Go-1.26.6-blue.svg)](https://golang.org/doc/devel/release.html)
 ![Claude Used](https://img.shields.io/badge/Claude-Used-4B5AEA)
 
 # Let's go... how do I make this work?!

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module ozskywalker/tiktok-favvideo-downloader
 
-go 1.25.1
+go 1.26.6


### PR DESCRIPTION
Updates go.mod and both workflows to Go 1.26.6, and bumps actions/checkout, actions/setup-go, actions/cache, golangci-lint-action, and action-gh-release to their latest releases (golangci-lint-action v9 also moves off the deprecated Node 20 Actions runtime onto Node 24).